### PR TITLE
Hide inactive moderators on /staff

### DIFF
--- a/www/staff/index.html
+++ b/www/staff/index.html
@@ -116,5 +116,5 @@ menu: |
 <h3>Donors</h3>
 <p><a href="/funding/#donations">List of all donors</a></p>
 <h3>Getting in Touch</h3>
-<p>You can find us on the <a href="/status">DDraceNetwork servers</a>,our <a href="//discordapp.com/invite/WJ9Xe7n">DDNet Discord server</a> and our <a href="ts3sever://ts.ddnet.tw">Teamspeak server on ts.ddnet.tw</a>. Otherwise you can post in our <a href="//forum.ddnet.tw/">Forum</a> for suggestions, questions or anything else. There's also an IRC channel <a href="irc://irc.quakenet.org/ddnet">#ddnet</a> on Quakenet (<a href="http://webchat.quakenet.org/?channels=ddnet&amp;uio=d4">Webchat</a>, <a href="/irclogs/">Logs</a>).
+<p>You can find us on the <a href="/status">DDraceNetwork servers</a>, our <a href="//discordapp.com/invite/WJ9Xe7n">DDNet Discord server</a> and our <a href="ts3sever://ts.ddnet.tw">Teamspeak server on ts.ddnet.tw</a>. Otherwise you can post in our <a href="//forum.ddnet.tw/">Forum</a> for suggestions, questions or anything else. There's also an IRC channel <a href="irc://irc.quakenet.org/ddnet">#ddnet</a> on Quakenet (<a href="http://webchat.quakenet.org/?channels=ddnet&amp;uio=d4">Webchat</a>, <a href="/irclogs/">Logs</a>).
 </div>

--- a/www/staff/index.html
+++ b/www/staff/index.html
@@ -47,12 +47,12 @@ menu: |
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=331">Im 'corneum</a></li>
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=1291">jao</a></li>
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=1522">Just a fish</a></li>
-  <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=95">Lady Saavik</a></li>
+  <!-- <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=95">Lady Saavik</a></li> -->
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=973">NeXus</a></li>
-  <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=525">Noez</a></li>
+  <!--  <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=525">Noez</a></li> -->
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=1365">Paralix</a></li>
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=367">=Pipou=</a></li>
-  <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=230">'qZ&nbsp;|BlaGK|›</a></li>
+  <!-- <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=230">'qZ&nbsp;|BlaGK|›</a></li> -->
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=380">RayB.</a></li>
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=709">Rico</a></li>
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=463">Ryozuki</a></li>
@@ -61,16 +61,16 @@ menu: |
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=142">Welf</a></li>
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=1251">☆.Sυsнι♪</a></li>
 </ul>
-<h4>RUS</h4>
-<ul class="staff">
-  <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=294">darky</a></li>
-  <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=49">milk</a></li>
-</ul>
+<!-- <h4>RUS</h4> -->
+<!-- <ul class="staff">  -->
+  <!-- <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=294">darky</a></li>  -->
+  <!-- <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=49">milk</a></li>  -->
+<!-- </ul>  -->
 <h4>Chile</h4>
 <ul class="staff">
-  <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=358">kosho</a></li>
+  <!--  <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=358">kosho</a></li> -->
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=1518">Neh</a></li>
-  <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=933">Pantoja</a></li>
+  <!--  <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=933">Pantoja</a></li> -->
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=968">Shocker</a></li>
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=985">Would?</a></li>
 </ul>
@@ -85,7 +85,7 @@ menu: |
 </ul>
 <h4>South Africa</h4>
 <ul class="staff">
-  <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=1010">Eagle</a></li>
+  <!-- <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=1010">Eagle</a></li> -->
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=600">garry</a></li>
   <li><a href="//forum.ddnet.tw/memberlist.php?mode=viewprofile&u=80">Super</a></li>
 </ul>


### PR DESCRIPTION
Because I have only seen the ["Inactive Moderator" Usergroup](https://forum.ddnet.tw/memberlist.php?mode=group&g=46) just now.