### PR TITLE
Minor fix

### DIFF
--- a/www/settingscommands/index.html
+++ b/www/settingscommands/index.html
@@ -356,8 +356,6 @@ menu: |
   <tr><td>cl_nameplates_clan_size</td><td>Size of the clan plates from 0 to 100%</td><td>30</td></tr>
   <tr><td>cl_nameplates_own</td><td>Show own name plate (useful for demo recording)</td><td>0</td></tr>
   <tr><td>cl_text_entities</td><td>Render textual entity data</td><td>1</td></tr>
-  <tr><td>cl_autoswitch_weapons</td><td>Auto switch weapon on pickup</td><td>1</td></tr>
-  <tr><td>cl_autoswitch_weapons_out_of_ammo</td><td>Auto switch weapon when out of ammo</td><td>1</td></tr>
   <tr><td>cl_autoswitch_weapons</td><td>Auto switch weapon on pickup</td><td>0</td></tr>
   <tr><td>cl_autoswitch_weapons_out_of_ammo</td><td>Auto switch weapon when out of ammo</td><td>0</td></tr>
   <tr><td>cl_showhud</td><td>Show ingame HUD</td><td>1</td></tr>
@@ -389,7 +387,6 @@ menu: |
   <tr><td>cl_dyncam_follow_factor</td><td>Dynamic camera follow factor</td><td>60</td></tr>
   <tr><td>ed_zoom_target</td><td>Zoom to the current mouse target</td><td>0</td></tr>
   <tr><td>ed_showkeys</td><td></td><td>0</td></tr>
-  <tr><td>cl_flow</td><td></td><td>0</td></tr>
   <tr><td>cl_show_welcome</td><td></td><td>1</td></tr>
   <tr><td>cl_motd_time</td><td>How long to show the server message of the day</td><td>10</td></tr>
   <tr><td>cl_ddnet_map_download_url</td><td>URL to use to download maps (can start with http:// or https://)</td><td>"https://maps.ddnet.tw"</td></tr>


### PR DESCRIPTION
cl_autoswitch_weapons & cl_autoswitch_weapons_out_of_ammo were displayed twice with both values, default is 0.
cl_flow just doesn't exist.