### PR TITLE
Update css-halloween.css

### DIFF
--- a/www/css-halloween.css
+++ b/www/css-halloween.css
@@ -21,7 +21,7 @@ a:hover {
 }
 @media (max-width: 1099px) {
   .fade {
-    background: linear-gradient(to left, #2D2D2D, rgba(216,239,255,0) 5em);
+    background: linear-gradient(to left, #2D2D2D, rgba(45,45,45,0) 5em);
   }
   .contentleft {
     background: transparent;


### PR DESCRIPTION
Should fix this fade bug in Safari:
<img src="https://user-images.githubusercontent.com/23143136/48967783-265dd400-efe6-11e8-843f-fd9f047b4cbd.jpeg" width="50%" height="50%">