### PR TITLE
Mirror libtw2 technical documentation

### DIFF
--- a/update_libtw2_doc.sh
+++ b/update_libtw2_doc.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+URL="/libtw2-doc"
+
+if [ -z "$1" ]; then
+	OUT_DIR="www/libtw2-doc"
+else
+	OUT_DIR="$1"
+fi
+
+INDEX="${OUT_DIR}/index.html"
+
+function file_names() {
+	echo connection.md,Connection
+	echo datafile.md,Datafile
+	echo demo.md,Demo
+	echo huffman.md,Huffman
+	echo int.md,Int
+	echo map.md,Map
+	echo packet.md,Packet
+	echo quirks.md,Quirks
+	echo serverinfo_extended.md,Serverinfo extended
+	echo snapshot.md,Snapshot
+	echo teehistorian.md,Teehistorian
+}
+
+function menu() {
+	echo "menu: |"
+	echo "  <ul>"
+	file_names | while read NAME TITLE
+	do
+		echo "    <li><a href=\"${URL}/${NAME/.md/}\">${TITLE}</a></li>"
+	done
+	echo "  </ul>"
+}
+
+
+function import_article() {
+	local REMOTE_NAME="$1"
+	local TITLE="$2"
+
+	echo "---"
+	echo "title: \"${TITLE}\""
+	echo "layout: default"
+	menu
+	echo "---"
+	echo '<div id="global" class="block">'
+	echo ""
+	echo "<h2>${TITLE}</h2>"
+	echo ""
+	echo "<!-- File imported from https://github.com/heinrich5991/libtw2/blob/master/doc/${REMOTE_NAME}. -->"
+	echo "<!-- Please create pull requests at https://github.com/heinrich5991/libtw2 if you want to edit this page. -->"
+	echo ""
+	echo '<small><i>This file is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small><br>'
+	echo ""
+
+	curl "https://raw.githubusercontent.com/heinrich5991/libtw2/master/doc/${REMOTE_NAME}" \
+		| pandoc --from gfm --to commonmark \
+		| sed 's/^#/###/g' \
+		| sed 's/\.md)/)/g' \
+		| pandoc --from commonmark --to html \
+
+	echo '</div>'
+
+	# add a link to the index page
+	echo "  <li><a href=\"${REMOTE_NAME/.md/}\">${TITLE}</a></li>" >> $INDEX
+}
+
+function generate_index_pre() {
+	echo "---"
+	echo "title: \"Libtw2 doc\""
+	echo "layout: default"
+	menu
+	echo "---"
+	echo '<div id="global" class="block">'
+	echo ""
+	echo "<!-- This is an auto generated file. If you want to make changes edit scripts/import-twmap2-doc.sh instead -->"
+	echo ""
+	echo "<h2>Libtw2 doc</h2> "
+	echo '<small><i>'
+	echo 'This section is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small>'
+	echo '</i></small><br>'
+	echo ""
+	echo "Technical documentation of Teeworlds file formats and network protocol"
+	echo ""
+	echo "<ul>"
+}
+
+function generate_index_post() {
+	echo "</ul>"
+	echo "</div>"
+}
+
+mkdir -p "$OUT_DIR"
+
+IFS=','
+
+# regenerate index page
+generate_index_pre > $INDEX
+
+file_names | while read NAME TITLE
+do
+	FILENAME="${OUT_DIR}/${NAME/.md/.html}"
+	echo "importing ${NAME} to ${FILENAME}"
+	import_article $NAME $TITLE > ${FILENAME}
+done
+
+generate_index_post >> $INDEX
+

--- a/www/libtw2-doc/connection.html
+++ b/www/libtw2-doc/connection.html
@@ -1,0 +1,42 @@
+---
+title: "Connection"
+layout: default
+menu: |
+  <ul>
+    <li><a href="/libtw2-doc/connection">Connection</a></li>
+    <li><a href="/libtw2-doc/datafile">Datafile</a></li>
+    <li><a href="/libtw2-doc/demo">Demo</a></li>
+    <li><a href="/libtw2-doc/huffman">Huffman</a></li>
+    <li><a href="/libtw2-doc/int">Int</a></li>
+    <li><a href="/libtw2-doc/map">Map</a></li>
+    <li><a href="/libtw2-doc/packet">Packet</a></li>
+    <li><a href="/libtw2-doc/quirks">Quirks</a></li>
+    <li><a href="/libtw2-doc/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/libtw2-doc/snapshot">Snapshot</a></li>
+    <li><a href="/libtw2-doc/teehistorian">Teehistorian</a></li>
+  </ul>
+---
+<div id="global" class="block">
+
+<h2>Connection</h2>
+
+<!-- File imported from https://github.com/heinrich5991/libtw2/blob/master/doc/connection.md. -->
+<!-- Please create pull requests at https://github.com/heinrich5991/libtw2 if you want to edit this page. -->
+
+<small><i>This file is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small><br>
+
+<pre><code>  -&gt; s:info
+  &lt;- s:map_change &lt;----------------------+
+[ -&gt; s:request_map_data ]                |
+[ &lt;- s:map_data ]                        |
+  -&gt; s:ready                             |
+[ &lt;- g:sv_motd ]                         |
+  &lt;- s:con_ready                         |
+  -&gt; g:client_start_info                 |
+[ &lt;- g:sv_vote_clear_options ]           |
+[ &lt;- g:sv_tune_params ]                  |
+  &lt;- g:sv_ready_to_enter                 |
+  -&gt; s:enter_game                        |
+  ingame --------------------------------+
+</code></pre>
+</div>

--- a/www/libtw2-doc/datafile.html
+++ b/www/libtw2-doc/datafile.html
@@ -1,0 +1,121 @@
+---
+title: "Datafile"
+layout: default
+menu: |
+  <ul>
+    <li><a href="/libtw2-doc/connection">Connection</a></li>
+    <li><a href="/libtw2-doc/datafile">Datafile</a></li>
+    <li><a href="/libtw2-doc/demo">Demo</a></li>
+    <li><a href="/libtw2-doc/huffman">Huffman</a></li>
+    <li><a href="/libtw2-doc/int">Int</a></li>
+    <li><a href="/libtw2-doc/map">Map</a></li>
+    <li><a href="/libtw2-doc/packet">Packet</a></li>
+    <li><a href="/libtw2-doc/quirks">Quirks</a></li>
+    <li><a href="/libtw2-doc/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/libtw2-doc/snapshot">Snapshot</a></li>
+    <li><a href="/libtw2-doc/teehistorian">Teehistorian</a></li>
+  </ul>
+---
+<div id="global" class="block">
+
+<h2>Datafile</h2>
+
+<!-- File imported from https://github.com/heinrich5991/libtw2/blob/master/doc/datafile.md. -->
+<!-- Please create pull requests at https://github.com/heinrich5991/libtw2 if you want to edit this page. -->
+
+<small><i>This file is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small><br>
+
+<h3>Introduction</h3>
+<p>The Teeworlds datafile format is the format which Teeworlds uses to save its game maps. Despite having been used for quite some time, it has not yet been formally described. The format enables one to store fixed-size &quot;items&quot; along with variable-sized &quot;data items&quot;.</p>
+<p>The format is designed in a way that makes it easy to directly load most parts into the memory (i. e. in version 4 everything except for the data block, as the data block is stored compressed in the file). In this document the versions 3 and 4 of Teeworlds datafiles will be explained.</p>
+<h3>Terminology</h3>
+<p>The following is an abstract description of the data contained in a Teeworlds datafile. It does not specify how they are laid out in the file.</p>
+<h4>Items</h4>
+<p>An item consists of a 16-bit unsigned integer <code>type_id</code>, a 16-bit unsigned integer <code>id</code> and an array of 32-bit signed integers <code>data</code>. The combination of <code>type_id</code> and <code>id</code> is unique amongst all items. The length of <code>data</code> is usually the same for all items of a given <code>type_id</code>.</p>
+<p>Examples of types in actual Teeworlds maps include metadata for layers, layer groups, images (external or not), etc. Since only the metadata and not the actual contents are stored, the items can remain fixed-size.</p>
+<h4>Data items</h4>
+<p>A data item is an array of bytes (8-bit unsigned integers) <code>data</code>. <code>id</code> is unique amongst all data items, the only possible IDs are from 0 (incl.) to the number of data items (excl.). These data items are indexed via unsigned integers, counting sequentially in the order they are laid out in the file.</p>
+<p>In actual Teeworlds maps, data items are used e.g. for the tiles of a tile layer or the image data of an embedded image. They are referred to in the metadata items by their index.</p>
+<h3>Format</h3>
+<h4>Datafile</h4>
+<p>The format of datafiles looks like follows, all parts are explained later:</p>
+<pre><code>datafile:
+    [  8] version_header
+    [ 28] header
+    [*12] item_types
+    [* 4] item_offsets
+    [* 4] data_offsets
+    [* 4] _data_sizes
+    [   ] items
+    [   ] data
+</code></pre>
+<p>The <code>_data_sizes</code> part is only present in version 4 of Teeworlds datafiles.</p>
+<p>The <code>header</code> contains size information for the rest of the file:</p>
+<ul>
+<li><code>item_types</code> has the length of <code>header.num_item_types</code> item types.</li>
+<li><code>item_offsets</code> has the length of <code>header.num_items</code> 32-bit integers.</li>
+<li><code>data_offsets</code> has the length of <code>header.num_data</code> 32-bit integers.</li>
+<li><code>_data_sizes</code> is only present in version 4 of Teeworlds datafiles, it has the length of <code>header.num_data</code> 32-bit integers.</li>
+<li><code>items</code> has the length of <code>header.item_size</code> bytes which must be divisible by four.</li>
+<li><code>data</code> has the length of <code>header.data_size</code> bytes.</li>
+</ul>
+<h4>Version header</h4>
+<p>The version header consists of a magic byte sequence, identifying the file as a Teeworlds datafile and a version number.</p>
+<pre><code>version_header:
+    [4] magic
+    [4] version
+</code></pre>
+<p>The <code>magic</code> must exactly be the ASCII representations of the four characters, 'D', 'A', 'T', 'A'.</p>
+<p>NOTE: Readers of Teeworlds datafiles should be able to read datafiles which start with a reversed <code>magic</code> too, that is 'A', 'T', 'A', 'D'. A bug in the reference implementation caused big-endian machines to save the reversed <code>magic</code> bytes.</p>
+<p>The <code>version</code> is a little-endian signed 32-bit integer, for version 3 or 4 of Teeworlds datafiles, it must be 3 or 4, respectively.</p>
+<h4>Header</h4>
+<p>The header specific to version 3 and 4 consists of seven 32-bit signed integers.</p>
+<pre><code>header:
+    [4] size
+    [4] swaplen
+    [4] num_item_types
+    [4] num_items
+    [4] num_data
+    [4] item_size
+    [4] data_size
+</code></pre>
+<p>The <code>size</code> is a little-endian integer and must be the size of the complete datafile without the <code>version_header</code> and both <code>size</code> and <code>swaplen</code>.</p>
+<p>NOTE: The reference implementation does not read this value.</p>
+<p>The <code>swaplen</code> is a little-endian integer and must specify the number of bytes containing integers following the <code>size</code> and <code>swaplen</code> fields, up until the data of the data items. It can therefore be used to reverse the endian on big-endian machines.</p>
+<p>NOTE: The reference implementation does not read datafiles correctly on little-endian machines, because it interprets <code>swaplen</code> as starting after the header.</p>
+<p>NOTE: All further integers can be assumed to be already converted to machine-native endian, if an endian swap was performed using the <code>swaplen</code> field.</p>
+<p>The <code>num_item_types</code> integer specifies the number of item types in the <code>datafile.item_types</code> field.</p>
+<p>The <code>num_items</code> integer specifies the number of items in the <code>datafile.items</code> field.</p>
+<p>The <code>num_data</code> integer specifies the number of raw data blocks in the <code>datafile.data</code> field.</p>
+<p>The <code>item_size</code> integer specifies the total size in bytes of the <code>datafile.items</code> field.</p>
+<p>The <code>data_size</code> integer specifies the total size in bytes of the <code>datafile.data</code> field.</p>
+<h4>Item types</h4>
+<p>The item types are an array of item types. The number of item types in that array is <code>num_item_types</code>, each item type is identified by its unique <code>type_id</code> (explained below). Each item type is of the following form:</p>
+<pre><code>item_type:
+    [4] type_id
+    [4] start
+    [4] num
+</code></pre>
+<p>The <code>type_id</code> 32-bit signed integer must be unique amongst all other <code>item_type.type_id</code>s. Its value must fit into an unsigned 16-bit integer.</p>
+<p>The <code>start</code> signed integer is the index of the first item in the <code>items</code> with the type <code>type_id</code>.</p>
+<p>The <code>num</code> signed integer must be the number of items with the the type <code>type_id</code>.</p>
+<p>NOTE: Since all items of the same type must be sequential in the <code>items</code> array, exactly the items with the index <code>start</code> (incl.) to <code>start + num</code> (excl.) are of the type <code>type_id</code>.</p>
+<h4>Item offsets, data offsets and data sizes</h4>
+<p>The item offsets, the data offsets and the data sizes are 32-bit signed integers.</p>
+<p>Each item offset is the offset of the item with the corresponding index, relative to the first item's position in the file.</p>
+<p>Each data offset is an offset of the data with the corresponding index, relative to the position of the first data item in the file. The data item's size can then be calculated from the next data item's offset or the size of the data section.</p>
+<p>Each data size is the size of the uncompressed data of the data with the corresponding index. Note that this field is only present in datafile version 4.</p>
+<h4>Items</h4>
+<p>This is an array of items. Each is of the following form:</p>
+<pre><code>item:
+    [4] type_id__id
+    [4] size
+    [ ] item_data
+</code></pre>
+<p>The <code>type_id__id</code> integer consists of 16 bit <code>type_id</code> of the type the item belongs to and 16 bit <code>id</code> that uniquely identifies the item among all others of the same type, in that order, i.e. the upper 16 bit of <code>type_id__id</code> specify the <code>type_id</code> and the lower 16 bit specify <code>id</code>.</p>
+<p>The <code>size</code> signed 32-bit integer is the size of the <code>item_data</code> field, in bytes, which must be divisible by four.</p>
+<p>NOTE: Neither the <code>type_id</code> nor the <code>size</code> are interpreted by the reference implementation.</p>
+<h4>Data</h4>
+<p>This section contains the data items. The order of the data items implicitly defines their ID.</p>
+<p>In version 3, this section solely consists of the concatenated data. In version 4, however, it stores the data compressed by zlib's <code>compress</code> function.</p>
+</div>

--- a/www/libtw2-doc/demo.html
+++ b/www/libtw2-doc/demo.html
@@ -1,0 +1,99 @@
+---
+title: "Demo"
+layout: default
+menu: |
+  <ul>
+    <li><a href="/libtw2-doc/connection">Connection</a></li>
+    <li><a href="/libtw2-doc/datafile">Datafile</a></li>
+    <li><a href="/libtw2-doc/demo">Demo</a></li>
+    <li><a href="/libtw2-doc/huffman">Huffman</a></li>
+    <li><a href="/libtw2-doc/int">Int</a></li>
+    <li><a href="/libtw2-doc/map">Map</a></li>
+    <li><a href="/libtw2-doc/packet">Packet</a></li>
+    <li><a href="/libtw2-doc/quirks">Quirks</a></li>
+    <li><a href="/libtw2-doc/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/libtw2-doc/snapshot">Snapshot</a></li>
+    <li><a href="/libtw2-doc/teehistorian">Teehistorian</a></li>
+  </ul>
+---
+<div id="global" class="block">
+
+<h2>Demo</h2>
+
+<!-- File imported from https://github.com/heinrich5991/libtw2/blob/master/doc/demo.md. -->
+<!-- Please create pull requests at https://github.com/heinrich5991/libtw2 if you want to edit this page. -->
+
+<small><i>This file is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small><br>
+
+<p>Unless specified otherwise, all of the following sizes are measured in bytes.</p>
+<pre><code>demo:
+    [  8] version_header
+    [168] header
+    [260] _timeline_markers
+    [   ] map
+    [   ] data
+</code></pre>
+<p><code>_timeline_markers</code> are only available in version 4 and 5.</p>
+<p>The length of the <code>map</code> field is determined by the <code>map_size</code> field in <code>header</code>. The <code>map</code> field contains a Teeworlds map (datafile).</p>
+<p><code>data</code> consists of many <code>chunk</code>s laid out one after the other.</p>
+<pre><code>version_header:
+    [  7] magic
+    [  1] version
+</code></pre>
+<p><code>magic</code> is &quot;TWDEMO\0&quot;.</p>
+<p><code>version</code> is any number from 3 to 5 for this document.</p>
+<pre><code>header:
+    [ 64] net_version
+    [ 64] map_name
+    [  4] map_size
+    [  4] map_crc
+    [  8] type
+    [  4] length
+    [ 20] timestamp
+</code></pre>
+<p><code>net_version</code>, <code>map_name</code>, <code>type</code> and <code>timestamp</code> are null-terminated strings. <code>map_size</code>, <code>map_crc</code> and <code>length</code> are signed big-endian 32-bit integers.</p>
+<p><code>map_size</code> determines the size of the <code>map</code> field of the demo.</p>
+<p><code>type</code> should be either &quot;client&quot; or &quot;server&quot; for a client or server demo, respectively.</p>
+<pre><code>_timeline_markers:
+    [  4] num_timeline_markers
+    [256] timeline_markers
+</code></pre>
+<p><code>num_timeline_markers</code> is a signed big-endian 32-bit integer. <code>timeline_markers</code> is an array of signed big-endian 32-bit integers of size 64.</p>
+<p><code>num_timeline_markers</code> gives the number of valid <code>timeline_markers</code>. This number should be less or equal to 64.</p>
+<pre><code>chunk:
+    [   ] chunk_header
+    [   ] chunk_data
+</code></pre>
+<p><code>chunk_header</code> is at least a single byte. If the <code>chunk</code> does not indicate a new tick, it looks like follows (sizes specified in bits):</p>
+<pre><code>chunk_header_normal_first:
+    [1] is_tick (set to 0 for normal chunks)
+    [2] type
+    [5] size
+
+0ttS SSSS
+</code></pre>
+<p><code>is_tick</code> is set to <code>0</code> for normal chunks.</p>
+<p><code>type</code> can be one of <code>1</code> (snapshot), <code>2</code> (message) or <code>3</code> (snapshot delta).</p>
+<p><code>size</code> determines the size of the following <code>chunk_data</code> unless one of the special values <code>30</code> or <code>31</code> are used. <code>30</code> indicates that <code>chunk_header</code> contains one additional byte whose numerical value specifies the length of the following <code>chunk_data</code>, <code>31</code> indicates that <code>chunk_header</code> contains one additional little-endian 16-bit integer specifying the length of the following <code>chunk_data</code>.</p>
+<p>If the <code>chunk</code> does indicate a new tick, its first byte looks like follows in version 3 and 4 (sizes specified in bits):</p>
+<pre><code>chunk_header_tick_first_34:
+    [1] is_tick (set to 1 for tick markers)
+    [1] keyframe
+    [6] tick_delta
+
+1kDD DDDD
+</code></pre>
+<p><code>is_tick</code> is set to <code>1</code> for tick markers.</p>
+<p><code>keyframe</code> is a hint to the demo player that the next tick will contain a full snapshot, which allows it to jump to that specific position.</p>
+<p><code>tick_delta</code> either specifies the tick delta (delta = difference) to the previous tick, or it is <code>0</code> to indicate that a big-endian 32-bit integer specifying the absolute tick follows.</p>
+<p>In version 5, the first byte of the <code>chunk_header</code> looks like follows if it does indicate a new tick (sizes specified in bits):</p>
+<pre><code>chunk_header_tick_first_5:
+    [1] is_tick (set to 1 for tick markers)
+    [1] keyframe
+    [1] inline_tick
+    [5] tick_delta
+
+1kiD DDDD
+</code></pre>
+<p><code>is_tick</code> and <code>keyframe</code> have the same meaning as in version 3 and 4. If <code>inline_tick</code> is <code>1</code>, <code>tick_delta</code> specifies the tick delta. If it is <code>0</code>, <code>tick_delta</code> is padding that should be zeroed and a big-endian 32-bit integer specifying the absolute tick follows.</p>
+</div>

--- a/www/libtw2-doc/huffman.html
+++ b/www/libtw2-doc/huffman.html
@@ -1,0 +1,322 @@
+---
+title: "Huffman"
+layout: default
+menu: |
+  <ul>
+    <li><a href="/libtw2-doc/connection">Connection</a></li>
+    <li><a href="/libtw2-doc/datafile">Datafile</a></li>
+    <li><a href="/libtw2-doc/demo">Demo</a></li>
+    <li><a href="/libtw2-doc/huffman">Huffman</a></li>
+    <li><a href="/libtw2-doc/int">Int</a></li>
+    <li><a href="/libtw2-doc/map">Map</a></li>
+    <li><a href="/libtw2-doc/packet">Packet</a></li>
+    <li><a href="/libtw2-doc/quirks">Quirks</a></li>
+    <li><a href="/libtw2-doc/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/libtw2-doc/snapshot">Snapshot</a></li>
+    <li><a href="/libtw2-doc/teehistorian">Teehistorian</a></li>
+  </ul>
+---
+<div id="global" class="block">
+
+<h2>Huffman</h2>
+
+<!-- File imported from https://github.com/heinrich5991/libtw2/blob/master/doc/huffman.md. -->
+<!-- Please create pull requests at https://github.com/heinrich5991/libtw2 if you want to edit this page. -->
+
+<small><i>This file is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small><br>
+
+<h3>Description</h3>
+<p>Teeworlds uses a huffman code to compress its network messages. The substitution works on bytes terminated by an EOF symbol (which means that there are 2^8+1 = 257 symbols). The specific substitutions can be seen in the appendix. The bitstream is padded with 0s until the number of bits is a multiple of 8, then the order of the bits in the individual bytes is reversed. This means a bitstream of <code>0123 4567 89ab cdef</code> ends up as:</p>
+<pre><code>7654 3210 fecb da98 ...
+|         |
+|         second byte
+first byte
+</code></pre>
+<p>NOTE: A bug in the reference implementation leads to an extra padding byte to be appended even if the bit stream already has a length that is a multiple of 8.</p>
+<p>NOTE: The reference implementation ignores the end of the byte stream during decompression and just assumes it is followed by an endless stream of zeros.</p>
+<h3>Example</h3>
+<p>That means, in order to encode the bytes</p>
+<pre><code>00 01 00 02 00 80 00
+</code></pre>
+<p>we first have to append an EOF symbol</p>
+<pre><code>00 01 00 02 00 80 00 EOF
+</code></pre>
+<p>and then we substitute according to the substitution table in the appendix</p>
+<pre><code>1 0001 1 01000 1 00000 1 010100011101100
+|  |   |  |    |  |    |  |
+00 01  00 02   00 80   00 EOF
+</code></pre>
+<p>group the encoding by bytes</p>
+<pre><code>1000 1101 0001 0000 0101 0100 0111 0110 0
+|         |         |         |         |
+1st byte  2nd byte  3rd byte  4th byte  5th byte
+</code></pre>
+<p>and pad with unset bits to full bytes</p>
+<pre><code>1000 1101 0001 0000 0101 0100 0111 0110 0000 0000
+                                         ^^^ ^^^^
+</code></pre>
+<p>and reverse the bits in each byte</p>
+<pre><code>1011 0001 0000 1000 0010 1010 0110 1110 0000 0000
+</code></pre>
+<p>We arrive at a representation that is two bytes shorter than the original (not only because it was carefully crafted).</p>
+<p>To decompress this byte stream, you just reverse the order and stop producing bytes once you reach the EOF symbol.</p>
+<h3>Appendix</h3>
+<pre><code>EOF: 010100011101100
+00: 1
+01: 0001
+02: 01000
+03: 01101000
+04: 011110
+05: 0110111
+06: 01101100
+07: 01110110
+08: 00100
+09: 0011001
+0a: 0101111
+0b: 01111111
+0c: 0100111
+0d: 011100
+0e: 00101111
+0f: 011101110
+10: 0101011
+11: 011001010
+12: 0011101
+13: 010101010
+14: 00001111
+15: 0111110110
+16: 001011000
+17: 001111100
+18: 0000100
+19: 001111001
+1a: 010010000
+1b: 000010110
+1c: 010100000
+1d: 0110011
+1e: 01010011
+1f: 0111010010
+20: 001101011
+21: 001100010
+22: 010111011
+23: 0110010111
+24: 000011000
+25: 010100010
+26: 010110111
+27: 010011010
+28: 0110101
+29: 01011100
+2a: 010010001
+2b: 0111111010
+2c: 001011011
+2d: 0110110101
+2e: 0111010001
+2f: 0110100110
+30: 0111010111
+31: 0111110010
+32: 0111110100
+33: 0101101011
+34: 00111100010
+35: 001110001011
+36: 0111110101100
+37: 010100011100
+38: 001010111010
+39: 000011100111
+3a: 000010100101
+3b: 001011100110
+3c: 0111110000111
+3d: 00101110000
+3e: 0110010110100
+3f: 010010101000
+40: 01010010
+41: 001111011
+42: 0101101010
+43: 0011000111
+44: 0101100110
+45: 0100110110
+46: 0011110000
+47: 0000111000
+48: 0011111010
+49: 00101001
+4a: 0101010010
+4b: 010101011
+4c: 0011000011
+4d: 0000101110
+4e: 01100100001
+4f: 01111110111
+50: 01110101000
+51: 01111101111
+52: 01111100000
+53: 0011011
+54: 0010100001
+55: 001101010
+56: 01011101000
+57: 01011000000
+58: 0000110011
+59: 01001010101
+5a: 0101000111010
+5b: 010110011110
+5c: 0101110100111
+5d: 001011100011
+5e: 0011111011100
+5f: 0101100111001
+60: 0101100111000
+61: 001110001010
+62: 0110110100011
+63: 0010101110001
+64: 001110010001
+65: 001110010000
+66: 0010111001111
+67: 0010111001110
+68: 0111010110101
+69: 0111010110100
+6a: 0101100111011
+6b: 0101100111010
+6c: 01110101001000
+6d: 001011100010
+6e: 0111010110111
+6f: 0110110100010
+70: 0101110100110
+71: 000011100110
+72: 00001110010
+73: 001011100101
+74: 000010100100
+75: 0110110100101
+76: 01111101011010
+77: 010100011101101
+78: 0111010110110
+79: 000010100111
+7a: 0010101110000
+7b: 0111010110001
+7c: 0110110100100
+7d: 001010101101
+7e: 01110101001001
+7f: 0011100011101
+80: 00000
+81: 0111111001
+82: 001101001
+83: 01111110110
+84: 010110001
+85: 01110111100
+86: 010010100
+87: 01110101011
+88: 010110100
+89: 01111100010
+8a: 010011001
+8b: 0010100000
+8c: 001011010
+8d: 01111110001
+8e: 001111111
+8f: 0011000110
+90: 011001001
+91: 01111110000
+92: 001101000
+93: 0000110010
+94: 011000
+95: 0101000110
+96: 010011000
+97: 01100100011
+98: 001011001
+99: 0100110111
+9a: 010101000
+9b: 01011101010
+9c: 010010111
+9d: 01111100011
+9e: 001110011
+9f: 0011100101
+a0: 001111110
+a1: 0101100001
+a2: 0111110011
+a3: 0111011111
+a4: 011011011
+a5: 001100000
+a6: 011010010
+a7: 0011000010
+a8: 010110110
+a9: 0110100111
+aa: 010110010
+ab: 0010101111
+ac: 010010110
+ad: 0000101111
+ae: 001010110
+af: 01111101110
+b0: 00001101
+b1: 001010100
+b2: 000011101
+b3: 01110101010
+b4: 000010101
+b5: 01100100010
+b6: 010100001
+b7: 01110100111
+b8: 001010001
+b9: 01110100110
+ba: 001110000
+bb: 01110111101
+bc: 001111010
+bd: 0111010000
+be: 001011101
+bf: 0101010011
+c0: 010111010111
+c1: 010010101101
+c2: 001111000111
+c3: 011011010011
+c4: 001110010011
+c5: 010111010110
+c6: 011111000010
+c7: 001111000110
+c8: 011111010101
+c9: 011011010000
+ca: 001110010010
+cb: 000010100110
+cc: 010100011111
+cd: 001111101101
+ce: 011101010011
+cf: 010010101100
+d0: 010010101111
+d1: 001111101100
+d2: 011001011001
+d3: 010111010010
+d4: 000010100001
+d5: 011001011000
+d6: 010100011110
+d7: 001010101100
+d8: 00111000100
+d9: 011001000001
+da: 0111010110000
+db: 001111101111
+dc: 0101100000101
+dd: 001010101111
+de: 001010101110
+df: 011001011011
+e0: 001110001101
+e1: 001010101001
+e2: 0111010110011
+e3: 001011100100
+e4: 0011111011101
+e5: 000010100000
+e6: 011111010111
+e7: 0101100000100
+e8: 001010101000
+e9: 0111010110010
+ea: 001010111011
+eb: 001010101011
+ec: 0111110000110
+ed: 011001000000
+ee: 000010100011
+ef: 001010101010
+f0: 01111101011011
+f1: 0011100011100
+f2: 010110011111
+f3: 010010101110
+f4: 010010101001
+f5: 000010100010
+f6: 001110001100
+f7: 0111110101001
+f8: 01010001110111
+f9: 0111110101000
+fa: 0111010100101
+fb: 001110001111
+fc: 0110010110101
+fd: 001010111001
+fe: 010110000011
+ff: 01001001
+</code></pre>
+</div>

--- a/www/libtw2-doc/index.html
+++ b/www/libtw2-doc/index.html
@@ -1,0 +1,43 @@
+---
+title: "Libtw2 doc"
+layout: default
+menu: |
+  <ul>
+    <li><a href="/libtw2-doc/connection">Connection</a></li>
+    <li><a href="/libtw2-doc/datafile">Datafile</a></li>
+    <li><a href="/libtw2-doc/demo">Demo</a></li>
+    <li><a href="/libtw2-doc/huffman">Huffman</a></li>
+    <li><a href="/libtw2-doc/int">Int</a></li>
+    <li><a href="/libtw2-doc/map">Map</a></li>
+    <li><a href="/libtw2-doc/packet">Packet</a></li>
+    <li><a href="/libtw2-doc/quirks">Quirks</a></li>
+    <li><a href="/libtw2-doc/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/libtw2-doc/snapshot">Snapshot</a></li>
+    <li><a href="/libtw2-doc/teehistorian">Teehistorian</a></li>
+  </ul>
+---
+<div id="global" class="block">
+
+<!-- This is an auto generated file. If you want to make changes edit scripts/import-twmap2-doc.sh instead -->
+
+<h2>Libtw2 doc</h2> 
+<small><i>
+This section is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small>
+</i></small><br>
+
+Technical documentation of Teeworlds file formats and network protocol
+
+<ul>
+  <li><a href="connection">Connection</a></li>
+  <li><a href="datafile">Datafile</a></li>
+  <li><a href="demo">Demo</a></li>
+  <li><a href="huffman">Huffman</a></li>
+  <li><a href="int">Int</a></li>
+  <li><a href="map">Map</a></li>
+  <li><a href="packet">Packet</a></li>
+  <li><a href="quirks">Quirks</a></li>
+  <li><a href="serverinfo_extended">Serverinfo extended</a></li>
+  <li><a href="snapshot">Snapshot</a></li>
+  <li><a href="teehistorian">Teehistorian</a></li>
+</ul>
+</div>

--- a/www/libtw2-doc/int.html
+++ b/www/libtw2-doc/int.html
@@ -1,0 +1,58 @@
+---
+title: "Int"
+layout: default
+menu: |
+  <ul>
+    <li><a href="/libtw2-doc/connection">Connection</a></li>
+    <li><a href="/libtw2-doc/datafile">Datafile</a></li>
+    <li><a href="/libtw2-doc/demo">Demo</a></li>
+    <li><a href="/libtw2-doc/huffman">Huffman</a></li>
+    <li><a href="/libtw2-doc/int">Int</a></li>
+    <li><a href="/libtw2-doc/map">Map</a></li>
+    <li><a href="/libtw2-doc/packet">Packet</a></li>
+    <li><a href="/libtw2-doc/quirks">Quirks</a></li>
+    <li><a href="/libtw2-doc/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/libtw2-doc/snapshot">Snapshot</a></li>
+    <li><a href="/libtw2-doc/teehistorian">Teehistorian</a></li>
+  </ul>
+---
+<div id="global" class="block">
+
+<h2>Int</h2>
+
+<!-- File imported from https://github.com/heinrich5991/libtw2/blob/master/doc/int.md. -->
+<!-- Please create pull requests at https://github.com/heinrich5991/libtw2 if you want to edit this page. -->
+
+<small><i>This file is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small><br>
+
+<h3>Introduction</h3>
+<p>The Teeworlds protocol has several where 32-bit signed integers are encoded using a variable-length encoding. This documents describes this encoding.</p>
+<h3>Format</h3>
+<p>All sizes are specified in bits, from the highest bit in a byte to the lowest.</p>
+<pre><code>first_byte:
+    [1] flag_extend
+    [1] flag_sign
+    [6] bits
+
+next_byte:
+    [1] flag_extend
+    [7] bits
+
+last_byte:
+    [4] padding
+    [4] bits
+
+int:
+    first_byte [next_byte [next_byte [next_byte [last_byte]]]]
+</code></pre>
+<p>As specified, an encoded <code>int</code> can have a size of 1 to 5 bytes. Some bytes have the <code>flag_extend</code> variable which specifies whether they're followed by another byte. The bits of the final integer are the <code>bits</code> fields combined, with a little-endian order. If we call our bits 0 to r, with 0 being the least significant bit, then it looks like this:</p>
+<pre><code>ES54 3210  Ecba 9876  Ejih gfed  Eqpo nmlk  PPPP utsr
+  ^^ ^^^^   ^^^ ^^^^   ^^^ ^^^^   ^^^ ^^^^       ^^^^
+</code></pre>
+<p>Always use the least amount of bytes possible to encode a number. The padding must always be zeroed.</p>
+<p>The <code>flag_sign</code> specifies that all the bits of the resulting number should be flipped, including the sign bit.</p>
+<p>NOTE: The reference implementation has no problem with accepting an overlong representation. The reference implementation also interprets the padding as part of the number, which leads to weird results. It should always be zeroed.</p>
+<h3>Examples</h3>
+<p>0 is encoded as <code>0000 0000</code>. 1 is encoded as <code>0000 0001</code>. -1 is encoded as <code>0100 0000</code> (note that the <code>bits</code> field is all zeros).</p>
+<p>64 is encoded as <code>1000 0000 0000 0001</code>.</p>
+</div>

--- a/www/libtw2-doc/map.html
+++ b/www/libtw2-doc/map.html
@@ -1,0 +1,600 @@
+---
+title: "Map"
+layout: default
+menu: |
+  <ul>
+    <li><a href="/libtw2-doc/connection">Connection</a></li>
+    <li><a href="/libtw2-doc/datafile">Datafile</a></li>
+    <li><a href="/libtw2-doc/demo">Demo</a></li>
+    <li><a href="/libtw2-doc/huffman">Huffman</a></li>
+    <li><a href="/libtw2-doc/int">Int</a></li>
+    <li><a href="/libtw2-doc/map">Map</a></li>
+    <li><a href="/libtw2-doc/packet">Packet</a></li>
+    <li><a href="/libtw2-doc/quirks">Quirks</a></li>
+    <li><a href="/libtw2-doc/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/libtw2-doc/snapshot">Snapshot</a></li>
+    <li><a href="/libtw2-doc/teehistorian">Teehistorian</a></li>
+  </ul>
+---
+<div id="global" class="block">
+
+<h2>Map</h2>
+
+<!-- File imported from https://github.com/heinrich5991/libtw2/blob/master/doc/map.md. -->
+<!-- Please create pull requests at https://github.com/heinrich5991/libtw2 if you want to edit this page. -->
+
+<small><i>This file is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small><br>
+
+<h3>Introduction</h3>
+<p>Teeworlds and DDNet maps get saved as datafiles. If you are not yet familiar with parsing datafiles, please go through the <a href="datafile">datafile documentation</a> first.</p>
+<h3>Terminology</h3>
+<ul>
+<li><p>integer types are usually declared in the same notation as in rust. Examples:</p>
+<ul>
+<li><code>i32</code> is a signed 32 bit integer</li>
+<li><code>u8</code> is a unsigned 8 bit integer, <code>byte</code> is used synonymously</li>
+</ul></li>
+<li><p><code>&amp;</code> is the prefix for data item indices. Those point to a data item in the <code>datafile.data</code> section of the datafile.</p></li>
+<li><p><code>opt</code> is the prefix for optional indices. They are either a normal index or <code>-1</code>, marking it as unused.</p></li>
+<li><p><code>*</code> is the prefix for indices that point to another item in the datafile.</p>
+<ul>
+<li>For example <code>*image</code> means that the field points to an image item. <code>*color_envelope</code> would mean that the field points to the envelope item with that index, which should be a color envelope.</li>
+</ul></li>
+<li><p><strong>CString</strong> is a null terminated UTF-8 string.</p></li>
+<li><p><strong>I32String</strong> is a CString stored in consecutive i32 values. To extract the string:</p>
+<ol>
+<li>convert the i32s to their be (big endian) byte representation, join the bytes so that we have a single array of bytes</li>
+<li>the last byte is a null byte, ignore that one for now</li>
+<li>wrapping-subtract 128 from the remaining bytes</li>
+<li>now you got a CString padded with zeroes</li>
+</ol></li>
+<li><p><strong>Point</strong> is a struct with two i32s, one for x, one for y. It is usually used to describe a position in the map. 0, 0 is the top-left corner.</p></li>
+<li><p><strong>Color</strong> is a struct with the 4 u8 values (in order): r, g, b, a. Its still usually parsed from 4 i32s, meaning each one should hold a value that fits into an u8.</p></li>
+<li><p>the <code>item_data</code> of an item is an array of i32s. We will split the <code>item_data</code> up into its different elements, which differ for each item type. Examples for the <code>item_data</code> syntax:</p>
+<ol>
+<li><code>[2] point: Point</code> =&gt; The next two i32 values represent the variable <code>point</code> (which will be explained afterwards) which is of the type <code>Point</code>.</li>
+<li><code>[1] opt &amp;name: CString</code> =&gt; The next i32 represents <code>name</code> and is an optional data item index to a CString.</li>
+</ol></li>
+</ul>
+<h3>Item Type Overview</h3>
+<pre><code>General map structure:
+    &gt; Info
+    &gt; Images
+    &gt; Envelopes
+        &gt; Envelope Points
+    &gt; Groups
+        &gt; Layers
+            &gt; Auto Mappers (DDNet only)
+    &gt; Sounds (DDNet only)
+</code></pre>
+<p>Maps consist of various elements that each have a <code>type_id</code> that identifies them.</p>
+<pre><code>type_id mappings:
+    0 -&gt; Version
+    1 -&gt; Info
+    2 -&gt; Images
+    3 -&gt; Envelopes
+    4 -&gt; Groups
+    5 -&gt; Layers
+    6 -&gt; Envelope Points
+    7 -&gt; Sounds (DDNet only)
+    0xffff -&gt; UUID Index (see below, DDNet only)
+</code></pre>
+<p>Use them to figure out which purpose each of the item types in the <code>datafile.item_types</code> section of the datafile has.</p>
+<p>Things to keep in mind:</p>
+<ol>
+<li>When an item type appears in <code>datafile.item_types</code>, it means that there must be at least one item of that type</li>
+<li>With the exception fo the UUID Index, the first item of an item type will have <code>id</code> = 0 and from there it will count up</li>
+</ol>
+<h4>UUID item types</h4>
+<p>In DDNet, some item types won't be assigned a type_id, but instead an uuid.</p>
+<p>To find the correct item type (in <code>datafile.item_types</code> for uuid item types, you will need their <code>type_id</code>. You will need to figure out the <code>type_id</code> manually by looking into the <strong>UUID Index items</strong>.</p>
+<pre><code>UUID Index Item structure:
+    type_id: 0xffff
+    id: type_id of the uuid item type that this item represents
+    item_data:
+        [3] UUID of the uuid item type that this item represents
+</code></pre>
+<ul>
+<li>the twelve bytes of the uuid are laid out in order in the <code>item_data</code> when viewing the integers as big endian</li>
+<li>steps to find an uuid item type:
+<ol>
+<li>get the UUID item type</li>
+<li>scan through its items</li>
+<li>when an item has the correct uuid in its <code>item_data</code>, copy the <code>type_id</code> from the <code>id</code> field</li>
+<li>find the item type with the <code>type_id</code> that we just found out</li>
+</ol></li>
+</ul>
+<h3>Map Item Types</h3>
+<h4>Version</h4>
+<ul>
+<li><code>type_id</code> = 0</li>
+<li>exactly one item</li>
+</ul>
+<!-- end list -->
+
+<pre><code>item_data of the only version item:
+    [1] version
+</code></pre>
+<ul>
+<li><code>version</code> = 1</li>
+<li>no actual data is stored using the Version item type</li>
+</ul>
+<h4>Info</h4>
+<ul>
+<li><code>type_id</code> = 1</li>
+<li>exactly one item</li>
+</ul>
+<!-- end list -->
+
+<pre><code>item_data of the only version item:
+    [1] (item) version
+    [1] opt &amp;author: CString
+    [1] opt &amp;version: CString
+    [1] opt &amp;credits: CString
+    [1] opt &amp;license: CString
+    [1] opt &amp;settings: [CString] (DDNet only)
+</code></pre>
+<ul>
+<li>both vanilla and DDNet are at <code>version</code> = 1</li>
+<li>like indicated, all the other fields are optional data item indices</li>
+<li>the data item behind <code>settings</code> is an array of CStrings, all consecutive, split by their null bytes (with a null byte at the very end)</li>
+<li>maximum amount of bytes for each CString (including the null byte):
+<ul>
+<li>author: 32</li>
+<li>version: 16</li>
+<li>credits: 128</li>
+<li>license: 32</li>
+</ul></li>
+</ul>
+<h4>Images</h4>
+<ul>
+<li><code>type_id</code> = 2</li>
+</ul>
+<!-- end list -->
+
+<pre><code>item_data of image items:
+    [1] version
+    [1] width
+    [1] height
+    [1] external: bool
+    [1] &amp;name: CString
+    [1] opt &amp;data: [Pixel]
+
+    version 2 extension (Vanilla only):
+    [1] variant
+</code></pre>
+<ul>
+<li>Vanilla is at <code>version</code> = 2, DDNet is at <code>version</code> = 1</li>
+<li><code>width</code> and <code>height</code> specify the dimensions of the image</li>
+<li>if <code>version</code> = 1, the image is of type RGBA, for <code>version</code> = 2 <code>variant</code> holds the type:
+<ul>
+<li>0 -&gt; RGB</li>
+<li>1 -&gt; RGBA</li>
+</ul></li>
+<li>Images can either be embedded or external.
+<ul>
+<li>Embedded images have <code>external</code> = false and have the image data stored in the data field. The image data is simply a 2d-array of pixels in row-major ordering. RGBA pixels are 4 bytes each, RGB pixels 3 bytes each.</li>
+<li>External images have <code>external</code> = true and the <code>data</code> field on <code>-1</code>. Those images can only be loaded by clients that have those in their <code>mapres</code> directory, meaning only a small set of images should be external. The client looks for those images by using the <code>name</code> field.</li>
+</ul></li>
+<li>the CString behind <code>name</code> must fit into 128 bytes</li>
+<li>External images for both 0.6 and 0.7 (note that they might differ between versions!): <code>bg_cloud1</code>, <code>bg_cloud2</code>, <code>bg_cloud3</code>, <code>desert_doodads</code>, <code>desert_main</code>, <code>desert_mountains2</code>, <code>desert_mountains</code>, <code>desert_sun</code>, <code>generic_deathtiles</code>, <code>generic_unhookable</code>, <code>grass_doodads</code>, <code>grass_main</code>, <code>jungle_background</code>, <code>jungle_deathtiles</code>, <code>jungle_doodads</code>, <code>jungle_main</code>, <code>jungle_midground</code>, <code>jungle_unhookables</code>, <code>moon</code>, <code>mountains</code>, <code>snow</code>, <code>stars</code>, <code>sun</code>, <code>winter_doodads</code>, <code>winter_main</code>, <code>winter_mountains2</code>, <code>winter_mountains3</code>, <code>winter_mountains</code></li>
+<li>Further external images for 0.7 maps: <code>easter</code>, <code>generic_lamps</code>, <code>generic_shadows</code>, <code>light</code></li>
+</ul>
+<h4>Envelopes</h4>
+<ul>
+<li><code>type_id</code> = 3</li>
+</ul>
+<!-- end list -->
+
+<pre><code>item_data of envelope items:
+    [1] version
+    [1] channels
+    [1] start_point
+    [1] num_points
+    
+    extension without version change:
+    [8] name: I32String
+    
+    version 2 extension:
+    [1] synchronized: bool
+</code></pre>
+<ul>
+<li>DDNet is at <code>version</code> = 2, Vanilla chooses 3 for all envelopes when one of them uses a bezier curve, but falls back to 2 when there is none.</li>
+<li><code>channel</code> holds the type of the envelope
+<ul>
+<li>1 -&gt; Sound envelope</li>
+<li>3 -&gt; Position envelope</li>
+<li>4 -&gt; Color envelope</li>
+</ul></li>
+<li><code>synchronized</code> has the effect that the envelope syncs to server time, not player join time</li>
+<li><code>start_point</code> is the index of its first envelope point</li>
+<li><code>num_points</code> is the number of envelope points for this envelope</li>
+</ul>
+<p>See Envelope Points to see how the envelope points are stored.</p>
+<h4>Envelope Points</h4>
+<ul>
+<li><code>type_id</code> = 6</li>
+<li>exactly one item</li>
+</ul>
+<p>The <code>item_data</code> of the only item contains all the envelope points used for the envelopes.</p>
+<ul>
+<li>Size of each envelope point:
+<ul>
+<li>22 i32s, if all envelopes have <code>version</code> = 3</li>
+<li>6 i32s, if all envelopes have a <code>version</code> &lt;= 2</li>
+</ul></li>
+<li>Note that all unused fields are zeroed</li>
+</ul>
+<p>The first 6 i32 of each envelope point, depending on the envelope type it belongs to:</p>
+<pre><code>sound envelope point:
+    [1] time
+    [1] curve type
+    [1] volume
+    [3] -
+
+position envelope point:
+    [1] time
+    [1] curve_type
+    [1] x
+    [1] y
+    [1] rotation
+    [1] -
+
+color envelope point:
+    [1] time
+    [1] curve type
+    [4] color: I32Color
+</code></pre>
+<ul>
+<li><p><code>time</code> is the timestamp of the point, it should increase monotonously within each envelope</p></li>
+<li><p><code>curve_type</code> holds how the curve should bend between this point and the next one</p>
+<ul>
+<li>0 -&gt; Step (abrupt drop at second value)</li>
+<li>1 -&gt; Linear (linear value change)</li>
+<li>2 -&gt; Slow (first slow, later much faster value change)</li>
+<li>3 -&gt; Fast (first fast, later much slower value change)</li>
+<li>4 -&gt; Smooth (slow, faster, then once more slow value change)</li>
+<li>5 -&gt; Bezier (Vanilla only, very customizable curve)</li>
+</ul></li>
+<li><p><code>x</code> and <code>y</code> hold the movement</p></li>
+<li><p><strong>I32Color</strong> actually means that the color values for r, g, b, a are i32 values</p></li>
+</ul>
+<p>If bezier curves are used anywhere (envelope version 3), then there are 16 more i32 for each point. These are only non-zero if the <code>curve_type</code> of the point is 5 (Bezier):</p>
+<pre><code>bezier point extension:
+    [4] in_tangent_dx
+    [4] in_tangent_dy
+    [4] out_tangent_dx
+    [4] out_tangent_dy
+</code></pre>
+<h4>Groups</h4>
+<ul>
+<li><code>type_id</code> = 4</li>
+</ul>
+<!-- end list -->
+
+<pre><code>item_data of group items
+    [1] version
+    [1] x_offset
+    [1] y_offset
+    [1] x_parallax
+    [1] y_parallax
+    [1] start_layer
+    [1] num_layers
+    
+    version 2 extension:
+    [1] clipping: bool
+    [1] clip_x
+    [1] clip_y
+    [1] clip_width
+    [1] clip_height
+    
+    version 3 extension:
+    [3] name: I32String
+</code></pre>
+<ul>
+<li>both Vanilla and DDNet are at <code>version</code> = 3</li>
+<li><code>start_layer</code> and <code>num_layers</code> tell you which layers belong to this group. Groups are not allowed to overlap, however, the reference implementation has no such checks while loading.</li>
+<li>the 'Game' group, which is the only one that is allowed to hold physics layers, should have every field zeroed, only <code>x_parallax</code> and <code>y_parallax</code> should each be 100 and the <code>name</code> should be &quot;Game&quot;. Note that the reference implementation does not verify this but instead just overwrites those values</li>
+<li>all maps must have a 'Game' group, since every map must have a 'Game' layer which can only be in the 'Game' group</li>
+</ul>
+<h4>Layers</h4>
+<ul>
+<li><code>type_id</code> = 5</li>
+</ul>
+<p>Layer types:</p>
+<ul>
+<li>Tilemap layers:
+<ul>
+<li>Tiles layer</li>
+<li>Physics layers:
+<ul>
+<li>Game layer</li>
+<li>Front layer (DDNet only)</li>
+<li>Tele layer (DDNet only)</li>
+<li>Speedup layer (DDNet only)</li>
+<li>Switch layer (DDNet only)</li>
+<li>Tune layer (DDNet only)</li>
+</ul></li>
+</ul></li>
+<li>Quads layer</li>
+<li>Sounds layer (DDNet only)</li>
+<li>Deprecated Sounds layer (DDNet only, replaced by Sounds layer)</li>
+</ul>
+<p>Note that:</p>
+<ol>
+<li>All physics layers <em>should</em> be unique, but this isn't properly enforced on all DDNet maps. The reference implementation uses the last physics layer of each type.</li>
+<li>All maps must have a Game layer</li>
+</ol>
+<!-- end list -->
+
+<pre><code>item_data base for all layer items (different types have different extensions):
+    [1] _version (not used, was uninitialized)
+    [1] type
+    [1] flags
+</code></pre>
+<ul>
+<li><code>flags</code> currently only has the detail flag (at 2^0), which is used in Quad-, Tile- and Sound layers.</li>
+<li><code>type</code> holds the type of layer:
+<ul>
+<li>2 -&gt; Tilemap layer</li>
+<li>3 -&gt; Quads layer</li>
+<li>9 -&gt; Deprecated Sounds layer</li>
+<li>10 -&gt; Sounds layer</li>
+</ul></li>
+</ul>
+<!-- end list -->
+
+<pre><code>item_data extension for tilemap layers:
+    [1] version
+    [1] width
+    [1] height
+    [1] type
+    [4] color: Color
+    [1] opt *color_envelope
+    [1] color_envelope_offset
+    [1] opt *image
+    [1] &amp;data: 2d-array of the the tile type &#39;Tile&#39;
+    
+    version 3 extension:
+    [3] name: I32String
+    
+    DDNet extension (no version change):
+    [1] opt &amp;data_tele
+    [1] opt &amp;data_speedup
+    [1] opt &amp;data_front
+    [1] opt &amp;data_switch
+    [1] opt &amp;data_tune
+</code></pre>
+<ul>
+<li><p>Vanilla is at <code>version</code> = 4, DDNet at <code>version</code> = 3</p></li>
+<li><p><code>width</code> and <code>height</code> specify the dimensions of the layer</p></li>
+<li><p><code>type</code> tells you what kind of tilemap layer this is:</p>
+<ul>
+<li>0 -&gt; Tiles</li>
+<li>1 -&gt; Game</li>
+<li>2 -&gt; Tele</li>
+<li>4 -&gt; Speedup</li>
+<li>8 -&gt; Front</li>
+<li>16 -&gt; Switch</li>
+<li>32 -&gt; Tune</li>
+</ul></li>
+<li><p><code>color</code>, <code>color_envelope</code>, <code>color_envelope_offset</code>, <code>image</code> are only used by the tiles layer</p></li>
+<li><p>all tile types consist of bytes (u8)</p></li>
+<li><p>all 2d-arrays of tiles use row-major ordering</p></li>
+<li><p>all tile types have the <code>id</code> byte, which identifies its use</p>
+<ul>
+<li>for example in the game layer, 0 is air, 1 is hookable, etc.</li>
+</ul></li>
+<li><p>many have a <code>flags</code> byte, which is a bitflag with the following bits:</p>
+<ul>
+<li>2^0 -&gt; vertical flip</li>
+<li>2^1 -&gt; horizontal flip</li>
+<li>2^2 -&gt; opaque</li>
+<li>2^3 -&gt; 90° rotation</li>
+<li>order of flips and rotations: vertical flip -&gt; horizontal flip -&gt; rotation</li>
+</ul></li>
+</ul>
+<!-- end list -->
+
+<pre><code>&#39;Tile&#39; tile type (consiting of bytes, used by all vanilla layers and the front layer):
+    [1] id
+    [1] flags
+    [1] skip
+    [1] - unused
+</code></pre>
+<ul>
+<li>the <code>skip</code> byte is used for the 0.7 compression, which is used if <code>version</code> &gt;= 4:
+<ul>
+<li>the <code>data</code> field no longer points to an 2d-array of tiles, but instead to an array of 'Tile' tiles which must be expanded into the 2d-array</li>
+<li>the <code>skip</code> field of each tile in the array tells you how many times this tile is used in a row. For example:
+<ul>
+<li>0 means that it appears only once there</li>
+<li>3 means that you need to add 3 more copies of that tile after this one</li>
+</ul></li>
+<li>note that the maximum value for <code>skip</code> is 255</li>
+<li>set the <code>skip</code> field to 0 while expanding
+<ul>
+<li>Teeworlds rendering assumes that those values are set to 0</li>
+<li>saving the tiles with 0.7 compression is less tedious, since you can check for equality of the entire tile struct</li>
+<li>saving the tiles again without the compression is less error prone. Since any saved map could be fed back into Teeworlds rendering, you need to set the <code>skip</code> values to 0 in this step</li>
+</ul></li>
+</ul></li>
+</ul>
+<p>DDNet only content:</p>
+<ul>
+<li>each physics layer uses a different data field pointer, keep in mind to use the correct one, when saving maps, set the unused pointers to -1</li>
+<li>the DDNet extension came before the <code>version</code> = 3 extension, meaning you have to subtract 3 (the length of the <code>name</code> field) from the data index</li>
+<li>you might have noticed that the <code>data</code> field is not actually optional like all the other data fields. For vanilla compatibility, the <code>data</code> field always points to a 2d-array of tiles of the type 'Tile', with the same dimensions as the actual layer, but everything zeroed out</li>
+</ul>
+<p>Special tile types:</p>
+<pre><code>&#39;Tele&#39; tile type (consiting of bytes):
+    [1] number
+    [1] id
+</code></pre>
+<ul>
+<li><code>number</code> is the number of the teleporter exit/entry to group them together</li>
+</ul>
+<!-- end list -->
+
+<pre><code>&#39;Speedup&#39; tile type (consiting of bytes):
+    [1] force
+    [1] max_speed
+    [1] id
+    [1] - unused padding byte
+    [2] angle: i16
+</code></pre>
+<ul>
+<li>angle is LE</li>
+</ul>
+<!-- end list -->
+
+<pre><code>&#39;Switch&#39; tile type (consiting of bytes):
+    [1] number
+    [1] id
+    [1] flags
+    [1] delay
+</code></pre>
+<ul>
+<li><code>number</code> once again tells you which tiles interact with each other</li>
+</ul>
+<!-- end list -->
+
+<pre><code>&#39;Tune&#39; tile type (consiting of bytes):
+    [1] number
+    [1] id
+</code></pre>
+<ul>
+<li><code>number</code> stores which zone this is, zones are defined in the map info -&gt; settings</li>
+</ul>
+<p><strong>Quads layer</strong></p>
+<pre><code>item_data extension for quads layers:
+    [1] version
+    [1] num_quads
+    [1] &amp;data: [Quads]
+    [1] opt *image
+    
+    version 2 extension:
+    [3] name: I32String
+</code></pre>
+<ul>
+<li>both Vanilla and DDNet are at <code>version</code> = 2</li>
+<li><code>num_quads</code> is the amount of quads found behind the data item pointer <code>data</code></li>
+<li>the size of a quad in bytes is 152, however we will pretend that the data consists of i32 when looking at the Quad structure:</li>
+</ul>
+<!-- end list -->
+
+<pre><code>Quad:
+    [2] position: Point
+    [8] corner_positions: [Point; 4]
+    [16] corner_colors: [Color; 4]
+    [8] texture_coordinates: [Point; 4]
+    [1] opt *position_envelope
+    [1] position_envelope_offset
+    [1] opt *color_envelope
+    [1] color_envelope_offset
+</code></pre>
+<ul>
+<li>corners are in the order top-left -&gt; top-right -&gt; bottom-left -&gt; bottom-right</li>
+</ul>
+<p><strong>Sounds layer</strong></p>
+<pre><code>item_data extension for sounds layers:
+    [1] version
+    [1] num_sources
+    [1] &amp;data: [SoundSource]
+    [1] opt *sound
+    [3] name: I32String
+</code></pre>
+<ul>
+<li>num_sources is the amount of sources behind the data item pointer <code>data</code></li>
+<li>the size of a sound source in bytes is 52, however we will pretend that the data consists of i32 when looking at the SoundSource structure:</li>
+<li>the CString behind <code>name</code> must fit into 128 bytes</li>
+</ul>
+<!-- end list -->
+
+<pre><code>SoundSource:
+    [2] position: Point
+    [1] looping: bool
+    [1] panning: bool
+    [1] delay (in seconds)
+    [1] falloff: u8
+    [1] *position_envelope
+    [1] position_envelope_offset
+    [1] *sound_envelope
+    [1] sound_envelope_offset
+    [3] shape: SoundShape
+
+SoundShape:
+    [1] kind
+    [1] width  / radius
+    [1] height / - unused
+</code></pre>
+<ul>
+<li><code>kind</code>:
+<ul>
+<li>0 -&gt; rectangle (use <code>width</code> and <code>height</code>)</li>
+<li>1 -&gt; circle (use <code>radius</code>)</li>
+</ul></li>
+</ul>
+<p><strong>Deprecated Sounds layer</strong></p>
+<ul>
+<li>the <code>item_data</code> is the same as in the Sounds layer</li>
+<li>difference is the SoundSource struct, which here only uses 36 bytes:</li>
+</ul>
+<!-- end list -->
+
+<pre><code>deprecated SoundSource:
+    [2] position: Point
+    [1] looping: bool
+    [1] delay
+    [1] radius
+    [1] *position_envelope
+    [1] position_envelope_offset
+    [1] *sound_envelope
+    [1] sound_envelope_offset
+</code></pre>
+<p>Use the following values to convert a deprecated SoundSource:</p>
+<ul>
+<li><code>panning</code> = true</li>
+<li><code>falloff</code> = 0</li>
+<li><code>shape</code>: kind = circle, with shared <code>radius</code></li>
+</ul>
+<h4>Sounds</h4>
+<ul>
+<li><code>type_id</code> = 7</li>
+<li>DDNet only</li>
+</ul>
+<!-- end list -->
+
+<pre><code>item_data of sound items:
+    [1] version
+    [1] external: bool
+    [1] &amp;name: CString
+    [1] &amp;data
+    [1] data_size
+</code></pre>
+<ul>
+<li>DDNet is at <code>version</code> = 1</li>
+<li>in theory, sounds can be external like images. However, since there are no sounds that could currently be loaded externally, this feature has been removed. This means that <code>external</code> should always be false and <code>data</code> should not be considered an option index</li>
+<li>the data item index <code>data</code> points to opus sound data</li>
+</ul>
+<h4>Auto Mappers</h4>
+<ul>
+<li><code>uuid</code> = <code>16271b3e-8c17-7839-9bd9-b11ae041d0d8</code></li>
+<li>DDNet only</li>
+</ul>
+<!-- end list -->
+
+<pre><code>item_data of auto mapper items:
+    [1] _version (not used, was uninitialized)
+    [1] *group
+    [1] *layer
+    [1] opt config
+    [1] seed
+    [1] flags
+</code></pre>
+<ul>
+<li><code>group</code> points to a group, <code>layer</code> is the layer index within the group</li>
+<li><code>flags</code> currently only has the <code>automatic</code> flag at 2^0, which tells the client to auto map after any changes</li>
+<li>while only Tiles layer use auto mappers, physics layers may also have one. When saving, only save auto mappers for Tiles layers</li>
+</ul>
+</div>

--- a/www/libtw2-doc/packet.html
+++ b/www/libtw2-doc/packet.html
@@ -1,0 +1,63 @@
+---
+title: "Packet"
+layout: default
+menu: |
+  <ul>
+    <li><a href="/libtw2-doc/connection">Connection</a></li>
+    <li><a href="/libtw2-doc/datafile">Datafile</a></li>
+    <li><a href="/libtw2-doc/demo">Demo</a></li>
+    <li><a href="/libtw2-doc/huffman">Huffman</a></li>
+    <li><a href="/libtw2-doc/int">Int</a></li>
+    <li><a href="/libtw2-doc/map">Map</a></li>
+    <li><a href="/libtw2-doc/packet">Packet</a></li>
+    <li><a href="/libtw2-doc/quirks">Quirks</a></li>
+    <li><a href="/libtw2-doc/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/libtw2-doc/snapshot">Snapshot</a></li>
+    <li><a href="/libtw2-doc/teehistorian">Teehistorian</a></li>
+  </ul>
+---
+<div id="global" class="block">
+
+<h2>Packet</h2>
+
+<!-- File imported from https://github.com/heinrich5991/libtw2/blob/master/doc/packet.md. -->
+<!-- Please create pull requests at https://github.com/heinrich5991/libtw2 if you want to edit this page. -->
+
+<small><i>This file is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small><br>
+
+<p>All sizes in bits.</p>
+<pre><code>packet_header:
+    [ 1] flag_compression
+    [ 1] flag_request_resend
+    [ 1] flag_connless
+    [ 1] flag_control
+    [ 2] padding
+    [10] ack
+    [ 8] num_chunks
+
+    FFFF ppAA  AAAA AAAA  nnnn nnnn
+</code></pre>
+<p>NOTE: <code>padding</code> must be zeroed, it's incorrectly used as part of the <code>ack</code> field while unpacking in the reference implementation.</p>
+<pre><code>chunk_header_vital:
+    [ 1] flag_resend
+    [ 1] flag_vital
+    [ 6] &lt;----------
+    [ 4] padding   |-- size
+    [ 4] &lt;----------
+
+    FFss ssss  PPPP ssss
+
+
+chunk_header_nonvital:
+    [ 1] flag_resend
+    [ 1] flag_vital
+    [ 6] &lt;----------
+    [ 4] sequence  |-- size
+    [ 4] &lt;----------
+    [ 8] sequence part 2
+
+    FFss ssss  SSSS ssss  SSSS SSSS
+</code></pre>
+<p>In the packed form, the first four bits of sequence correspond to bits 10 to 6, and the second part corresponds to the bits 8 to 1.</p>
+<p>NOTE: The reference implementation just uses bitwise-or to resolve contradictions in the overlapping bits.</p>
+</div>

--- a/www/libtw2-doc/quirks.html
+++ b/www/libtw2-doc/quirks.html
@@ -1,0 +1,37 @@
+---
+title: "Quirks"
+layout: default
+menu: |
+  <ul>
+    <li><a href="/libtw2-doc/connection">Connection</a></li>
+    <li><a href="/libtw2-doc/datafile">Datafile</a></li>
+    <li><a href="/libtw2-doc/demo">Demo</a></li>
+    <li><a href="/libtw2-doc/huffman">Huffman</a></li>
+    <li><a href="/libtw2-doc/int">Int</a></li>
+    <li><a href="/libtw2-doc/map">Map</a></li>
+    <li><a href="/libtw2-doc/packet">Packet</a></li>
+    <li><a href="/libtw2-doc/quirks">Quirks</a></li>
+    <li><a href="/libtw2-doc/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/libtw2-doc/snapshot">Snapshot</a></li>
+    <li><a href="/libtw2-doc/teehistorian">Teehistorian</a></li>
+  </ul>
+---
+<div id="global" class="block">
+
+<h2>Quirks</h2>
+
+<!-- File imported from https://github.com/heinrich5991/libtw2/blob/master/doc/quirks.md. -->
+<!-- Please create pull requests at https://github.com/heinrich5991/libtw2 if you want to edit this page. -->
+
+<small><i>This file is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small><br>
+
+<ul>
+<li>Huffman compression has an extra byte if the actual end is at a byte boundary.</li>
+<li>The size field has a weird splitting in the chunk header.</li>
+<li>The ack field of the packet header is 12 instead of 10 bit wide.</li>
+<li>The sequence field of the chunk header has overlapping bits.</li>
+<li>The client doesn't care about the actual lengths of the snapshot chunks, it'll always pad to <code>MAX_SNAPSHOT_PADSIZE</code>.</li>
+<li>The client wants to receive the last snapshot part last, otherwise the resulting delta is too long.</li>
+<li>CCharacterCore has unused fields <code>m_HookDx</code>, <code>m_HookDy</code></li>
+</ul>
+</div>

--- a/www/libtw2-doc/serverinfo_extended.html
+++ b/www/libtw2-doc/serverinfo_extended.html
@@ -1,0 +1,109 @@
+---
+title: "Serverinfo extended"
+layout: default
+menu: |
+  <ul>
+    <li><a href="/libtw2-doc/connection">Connection</a></li>
+    <li><a href="/libtw2-doc/datafile">Datafile</a></li>
+    <li><a href="/libtw2-doc/demo">Demo</a></li>
+    <li><a href="/libtw2-doc/huffman">Huffman</a></li>
+    <li><a href="/libtw2-doc/int">Int</a></li>
+    <li><a href="/libtw2-doc/map">Map</a></li>
+    <li><a href="/libtw2-doc/packet">Packet</a></li>
+    <li><a href="/libtw2-doc/quirks">Quirks</a></li>
+    <li><a href="/libtw2-doc/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/libtw2-doc/snapshot">Snapshot</a></li>
+    <li><a href="/libtw2-doc/teehistorian">Teehistorian</a></li>
+  </ul>
+---
+<div id="global" class="block">
+
+<h2>Serverinfo extended</h2>
+
+<!-- File imported from https://github.com/heinrich5991/libtw2/blob/master/doc/serverinfo_extended.md. -->
+<!-- Please create pull requests at https://github.com/heinrich5991/libtw2 if you want to edit this page. -->
+
+<small><i>This file is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small><br>
+
+<p>In the following document, &quot;vanilla&quot; refers to unmodified Teeworlds.</p>
+<h3>Extended server info request</h3>
+<p>An extended server info can be requested from the Teeworlds server by sending the following UDP packet:</p>
+<pre><code>[2] magic_bytes
+[2] extra_token
+[2] reserved
+[4] padding
+[4] vanilla_request
+[1] token
+</code></pre>
+<p><code>magic_bytes</code> must be the ASCII representation of &quot;xe&quot;.</p>
+<p><code>extra_token</code> contains a 16 bit big-endian integer that should be shifted by 8 to the left and combined with <code>token</code> with a bitwise or, before the extended server info is sent back.</p>
+<p><code>reserved</code> is reserved for future protocol versions and must be zeroed by the sender and ignored by the receiver with this protocol version.</p>
+<p><code>padding</code> must be filled with 0xff bytes.</p>
+<p><code>vanilla_request</code> must be the ASCII representation of &quot;gie3&quot;.</p>
+<p><code>token</code> is an arbitrary byte chosen by the client which will be sent back with the server info. For the extended server info, the <code>extra_token</code> field needs to be included in the server info response.</p>
+<p>If a server receives such a request (detected by the <code>magic_bytes</code> field), it can either respond with the vanilla server info, or by sending the extended server info, described in the following.</p>
+<p>If the server does not recognize the <code>magic_bytes</code>, it should send back the vanilla server info.</p>
+<h3>Extended server info</h3>
+<p>The extended server info can consist of several packets, the &quot;main&quot; packet and the &quot;more&quot; packets, which can contain additional player data in case they don't fit in the first packet.</p>
+<p>The <code>str</code> type is a zero-terminated UTF-8 string. Implementations should be prepared to either replace invalid UTF-8 with the replacement character or to treat these fields as opaque zero-terminated byte sequences.</p>
+<p>The <code>int</code> type is an integer encoded in the decimal system in a zero-terminated ASCII string.</p>
+<p>NOTE: The reference implementation clears control characters (replacing bytes with a value of less than 32 with the ASCII space ' ') and skips leading whitespace in all strings.</p>
+<p>The receiver of such a server info can detect whether it has received the server info completely by comparing the number of players received with the number of players set in the main packet.</p>
+<h4>The main packet</h4>
+<p>The main server info packet looks like follows:</p>
+<pre><code>[ 10] padding
+[  4] type
+[int] token
+[str] version
+[str] name
+[str] map
+[int] map_crc
+[int] map_size
+[str] game_type
+[int] flags
+[int] num_players
+[int] max_players
+[int] num_clients
+[int] max_clients
+[str] reserved
+[  *] players
+</code></pre>
+<p><code>padding</code> must be filled with 0xff bytes.</p>
+<p><code>type</code> must be the ASCII representation of &quot;iext&quot;.</p>
+<p><code>token</code> must be the token from the request. If the server info isn't sent upon a request, it mut be -1.</p>
+<p><code>version</code> contains the server version. The first three bytes must equal the client's version, otherwise it will be filtered out as &quot;incompatible version&quot;.</p>
+<p><code>name</code>, <code>map</code>, <code>game_type</code> are the server's name, its current map and gametype, respectively. <code>map_crc</code> is the current map's CRC (note that Teeworlds uses incorrect starting values to calculate the CRC) and <code>map_size</code> is the map's size in bytes.</p>
+<p>There is currently only one flag for the <code>flags</code> field, namely the password flag, whose value is 1. It must be set if entering the server requires a password, and unset in the other case.</p>
+<p><code>num_players</code>, <code>max_players</code>, <code>num_clients</code>, <code>max_clients</code>: These values describe how many players (people that are not in &quot;spectator mode&quot;) and clients (people that are connected to the server) the server currently has (<code>num_*</code>) and is able to handle (<code>max_*</code>). The following natural inequalities must hold:</p>
+<pre><code>                 &lt;= max_players
+0 &lt;= num_players                &lt;= max_clients
+                 &lt;= num_clients
+</code></pre>
+<p>Note that there is no upper limit for <code>max_clients</code> enforced by the protocol.</p>
+<p>The field <code>reserved</code> is reserved for future protocol versions. Senders of this message must set the field to the empty string, and receivers of this message must ignore its value.</p>
+<p><code>players</code> contains the player info described further below.</p>
+<h4>The &quot;more&quot; packet</h4>
+<p>A &quot;more&quot; packet looks like this:</p>
+<pre><code>[ 10] padding
+[  4] type
+[int] token
+[int] packet_no
+[str] reserved
+[  *] players
+</code></pre>
+<p><code>padding</code>, <code>token</code>, <code>reserved</code>, <code>players</code>: See the explanation on the main packet.</p>
+<p><code>type</code> must contain the ASCII representation of &quot;iex+&quot;.</p>
+<p><code>packet_no</code> must be packet number in the server info response. It must be greater than 0 and less than 64. The main packet has an implicit <code>packet_no</code> of 0. This field can be used to detect duplicated packets.</p>
+<h4>Player info</h4>
+<p>A single player info is defined as:</p>
+<pre><code>[str] name
+[str] clan
+[int] country
+[int] score
+[int] is_player
+[str] reserved
+</code></pre>
+<p>The <code>name</code>, <code>clan</code> and <code>score</code> field contain the player's name, clan and score, respectively.</p>
+<p>The <code>country</code> field contains the ISO 3166-1 numeric code of the player's country, or -1 if unset.</p>
+<p>The <code>is_player</code> field contains a non-zero integer if the player is not a spectator, and 0 otherwise. Producers of this message should always use 1 to indicate a non-spectator client.</p>
+</div>

--- a/www/libtw2-doc/snapshot.html
+++ b/www/libtw2-doc/snapshot.html
@@ -1,0 +1,74 @@
+---
+title: "Snapshot"
+layout: default
+menu: |
+  <ul>
+    <li><a href="/libtw2-doc/connection">Connection</a></li>
+    <li><a href="/libtw2-doc/datafile">Datafile</a></li>
+    <li><a href="/libtw2-doc/demo">Demo</a></li>
+    <li><a href="/libtw2-doc/huffman">Huffman</a></li>
+    <li><a href="/libtw2-doc/int">Int</a></li>
+    <li><a href="/libtw2-doc/map">Map</a></li>
+    <li><a href="/libtw2-doc/packet">Packet</a></li>
+    <li><a href="/libtw2-doc/quirks">Quirks</a></li>
+    <li><a href="/libtw2-doc/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/libtw2-doc/snapshot">Snapshot</a></li>
+    <li><a href="/libtw2-doc/teehistorian">Teehistorian</a></li>
+  </ul>
+---
+<div id="global" class="block">
+
+<h2>Snapshot</h2>
+
+<!-- File imported from https://github.com/heinrich5991/libtw2/blob/master/doc/snapshot.md. -->
+<!-- Please create pull requests at https://github.com/heinrich5991/libtw2 if you want to edit this page. -->
+
+<small><i>This file is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small><br>
+
+<h3>Introduction</h3>
+<p>Teeworlds uses this format of so called &quot;snapshots&quot; to transmit the current state of the world over the network. The format allows one to transmit fixed-size &quot;items&quot;.</p>
+<h3>Terminology</h3>
+<p>All integers in this document are little-endian integers.</p>
+<h4>Item key</h4>
+<p>An item key is a 32-bit unsigned integer that contains the 16-bit unsigned integer <code>type_id</code> as the upper bits and <code>id</code> as the lower bits.</p>
+<h4>Items</h4>
+<p>An item consists of an item key <code>key</code> and an array of 32-bit signed integers <code>data</code>.</p>
+<h4>Snapshot</h4>
+<p>A snapshot is a collection of items identified by their key.</p>
+<h3>Format</h3>
+<h4>Checksum calculation</h4>
+<p>The checksum of a snapshot is calculated by summing all the <code>data</code> array elements of all items, using wrapping overflow behavior.</p>
+<h4>Snapshot deltas</h4>
+<pre><code>snapshot_delta:
+    [ 4] num_removed_items
+    [ 4] num_item_deltas
+    [ 4] _zero
+    [*4] removed_item_keys
+    [  ] item_deltas
+</code></pre>
+<p>Snapshot deltas are used to describe the differences between two snapshots, the &quot;old&quot; and the &quot;new&quot; one. You can use the delta together with the old snapshot to construct the new one. Note that the reverse does not work, because the values of snapshot items present in the old but not the new snapshot are not recorded in the delta.</p>
+<ul>
+<li><code>num_removed_items</code> is a positive signed 32-bit integer describing the length of the <code>removed_item_keys</code> array.</li>
+<li><code>num_item_deltas</code> is a positive signed 32-bit integer describing the number of item deltas in the <code>item_deltas</code> field.</li>
+<li><code>_zero</code> is a padding field which must be zeroed by any snapshot delta writer and ignored by any snapshot delta reader.</li>
+<li><code>removed_item_keys</code> is an array of <code>num_removed_items</code> item keys that are present in old snapshot, but not in the new one.</li>
+<li><code>item_deltas</code> is a concatenation of <code>num_item_deltas</code> item deltas.</li>
+</ul>
+<h4>Item deltas</h4>
+<pre><code>item_delta:
+    [ 4] type_id
+    [ 4] id
+    [ 4] _size
+    [*4] data_delta
+</code></pre>
+<ul>
+<li><code>type_id</code> is a 32-bit unsigned integer containing the 16-bit type id of the item.</li>
+<li><code>id</code> is 32-bit unsigned integer containing the 16-bit id of the item.</li>
+<li><code>_size</code> is a field that is only present if the size of items of type <code>type_id</code> is not pre-agreed for the protocol. A list of pre-agreed item sizes can be found in the appendix of this document.</li>
+<li><code>data_delta</code> is the data delta (an array of <code>_size</code> 32-bit signed integers). If the item was not present in the old snapshot (determined by the item key), then <code>data_delta</code> just contains the new item data. Otherwise, the <code>data_delta</code> needs to be added onto the current item's data (elementwise) using 32-bit integer addition that wraps around on overflow. Note that in the case of item update, the new size must be the same as the old size of the item data.</li>
+</ul>
+<h3>Appendix</h3>
+<h4>Pre-agreed item sizes</h4>
+<p>This describes the 0.6 protocol of Teeworlds.</p>
+<p><code>type_id</code> | <code>size</code> | name ----------+--------+-------------- 1 | 10 | obj_player_input 2 | 6 | obj_projectile 3 | 5 | obj_laser 4 | 4 | obj_pickup 5 | 3 | obj_flag 6 | 8 | obj_game_info 7 | 4 | obj_game_data 8 | 15 | obj_character_core 9 | 22 | obj_character 10 | 5 | obj_player_info 11 | 17 | obj_client_info 12 | 3 | obj_spectator_info 13 | 2 | event_common 14 | 2 | event_explosion 15 | 2 | event_spawn 16 | 2 | event_hammerhit 17 | 3 | event_death 18 | 3 | event_sound_global 19 | 3 | event_sound_world 20 | 3 | event_damage_indicator</p>
+</div>

--- a/www/libtw2-doc/teehistorian.html
+++ b/www/libtw2-doc/teehistorian.html
@@ -1,0 +1,130 @@
+---
+title: "Teehistorian"
+layout: default
+menu: |
+  <ul>
+    <li><a href="/libtw2-doc/connection">Connection</a></li>
+    <li><a href="/libtw2-doc/datafile">Datafile</a></li>
+    <li><a href="/libtw2-doc/demo">Demo</a></li>
+    <li><a href="/libtw2-doc/huffman">Huffman</a></li>
+    <li><a href="/libtw2-doc/int">Int</a></li>
+    <li><a href="/libtw2-doc/map">Map</a></li>
+    <li><a href="/libtw2-doc/packet">Packet</a></li>
+    <li><a href="/libtw2-doc/quirks">Quirks</a></li>
+    <li><a href="/libtw2-doc/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/libtw2-doc/snapshot">Snapshot</a></li>
+    <li><a href="/libtw2-doc/teehistorian">Teehistorian</a></li>
+  </ul>
+---
+<div id="global" class="block">
+
+<h2>Teehistorian</h2>
+
+<!-- File imported from https://github.com/heinrich5991/libtw2/blob/master/doc/teehistorian.md. -->
+<!-- Please create pull requests at https://github.com/heinrich5991/libtw2 if you want to edit this page. -->
+
+<small><i>This file is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small><br>
+
+<h3>Introduction</h3>
+<p>The DDNet teehistorian format is the format which DDNet uses to save all input to a server in order to be able to reproduce it faithfully. A teehistorian file is fundamentally a stream of messages that describe input to the server and a little data for sanity checks.</p>
+<p>The format is designed in a way to make it easily compressible using standard compression algorithms in order to make it suitable for long-term storage, which Teeworlds demos are not due to their large size. It is easy to write out in a stream (you just append data at the end) but for reading, one has to read the whole file end-to-end because the format does not support seeking.</p>
+<p>This document describes version 1 and 2 of the teehistorian file format. The only difference between them is the existence of the <code>EX</code> message (see below).</p>
+<h3>Format</h3>
+<p>A teehistorian file is fundamentally a header followed by a stream of messages.</p>
+<h4>Header</h4>
+<p>The header starts with the teehistorian UUID (699db17b-8efb-34ff-b1d8-da6f60c15dd1, version 3 UUID derived from the Teeworlds namespace e05ddaaa-c4e6-4cfb-b642-5d48e80c0029 and the name &quot;<a href="mailto:teehistorian@ddnet.tw">teehistorian@ddnet.tw</a>&quot;), encoded as a <a href="https://en.wikipedia.org/w/index.php?title=Universally_unique_identifier&amp;oldid=844235295#Encoding">big endian binary encoded UUID</a> (16 bytes). It is followed by a null-terminated string that contains a JSON object containing at least the following keys:</p>
+<ul>
+<li><code>version</code>: This is the version number of the teehistorian format. It must be <code>&quot;1&quot;</code> or <code>&quot;2&quot;</code> for this document.</li>
+</ul>
+<h4>Messages</h4>
+<p>Each message starts with a Teeworlds variable-width integer, which is the message ID.</p>
+<ul>
+<li>PLAYER_DIFF(0-63): dx(int) dy(int) records that player with the message ID as cid (client ID) has changed position in a way that adds dx to the x coordinate and y to the y coordinate</li>
+<li>FINISH(-1): records the end of the teehistorian file</li>
+<li>TICK_SKIP(-2): dt(int) records that there were dt ticks in which nothing happened, i.e. the next tick is the last tick + dt + 1</li>
+<li>PLAYER_NEW(-3): cid(int) x(int) y(int) records that a new player character with cid appeared at (x, y)</li>
+<li>PLAYER_OLD(-4): cid(int) records that the player character with cid disappeared</li>
+<li>INPUT_DIFF(-5): cid(int) dinput(int[10]) records that a player with cid sent an input packet but has sent one before, add dinput to the previous input component-wise to obtain the new one</li>
+<li>INPUT_NEW(-6): cid(int) input(int[10]) records that a player with cid sent an input packet for the first time, containing input</li>
+<li>MESSAGE(-7): cid(int) msgsize(int) msg(raw[msgsize]) records that a player with cid sent a game-related packet msg</li>
+<li>JOIN(-8): cid(int) records that a player with cid joined, on the engine level</li>
+<li>DROP(-9): cid(int) reason(str) records that a player with cid left/was kicked/was dropped, on the engine level</li>
+<li>CONSOLE_COMMAND(-10): cid(int) flags(int) cmd(str) num_args(int) args(str[num_args]) records that a console command cmd was executed by client id cid (not necessarily a player, might be a vote as well), with flags (distinguishes chat commands, etc.) with parameters args</li>
+<li>EX(-11): uuid(uuid) size(int) data(raw[size]) records an extension message, identified by uuid and containing data
+<ul>
+<li>introduced in DDNet 11.0.3, <a href="https://github.com/ddnet/ddnet/commit/6c378b972b70b0556d3b434b26baa0b9ffe490f1">6c378b972b70b055</a></li>
+</ul></li>
+</ul>
+<p>The following extra messages are known right now:</p>
+<ul>
+<li>TEST(<a href="mailto:teehistorian-test@ddnet.tw">teehistorian-test@ddnet.tw</a>): is just a test message
+<ul>
+<li>uuid: 6bb8ba88-0f0b-382e-8dae-dbf4052b8b7d</li>
+<li>introduced in DDNet 11.0.3, <a href="https://github.com/ddnet/ddnet/commit/6c378b972b70b0556d3b434b26baa0b9ffe490f1">6c378b972b70b055</a></li>
+</ul></li>
+<li>DDNETVER_OLD(<a href="mailto:teehistorian-ddnetver-old@ddnet.tw">teehistorian-ddnetver-old@ddnet.tw</a>): cid(int), version(int)
+<ul>
+<li>uuid: 41b49541-f26f-325d-8715-9baf4b544ef9</li>
+<li>introduced in DDNet 13.2, <a href="https://github.com/ddnet/ddnet/commit/0d7872c79eaeb19b3fd08c39c013a1043db1fd9b">0d7872c79eaeb19b</a></li>
+</ul></li>
+<li>DDNETVER(<a href="mailto:teehistorian-ddnetver@ddnet.tw">teehistorian-ddnetver@ddnet.tw</a>): cid(int), connection_id(uuid), version(int), version_str(str)
+<ul>
+<li>uuid: 1397b63e-ee4e-3919-b86a-b058887fcaf5</li>
+<li>introduced in DDNet 13.2, <a href="https://github.com/ddnet/ddnet/commit/0d7872c79eaeb19b3fd08c39c013a1043db1fd9b">0d7872c79eaeb19b</a></li>
+</ul></li>
+<li>AUTH_INIT(<a href="mailto:teehistorian-auth-init@ddnet.tw">teehistorian-auth-init@ddnet.tw</a>): cid(int) level(int) auth_name(str) records that a player with cid got rcon access with level under the account name auth_name since the start of the map (because they had it before the map change as well)
+<ul>
+<li>uuid: 60daba5c-52c4-3aeb-b8ba-b2953fb55a17</li>
+<li>introduced in DDNet 11.0.3, <a href="https://github.com/ddnet/ddnet/commit/1c3dc8c316c2bf37b94814d390c1c214422d46a9">1c3dc8c316c2bf37</a></li>
+</ul></li>
+<li>AUTH_LOGIN(<a href="mailto:teehistorian-auth-login@ddnet.tw">teehistorian-auth-login@ddnet.tw</a>): cid(int) level(int) auth_name(str) records that a player with cid just logged into rcon with level under the account name auth_name
+<ul>
+<li>uuid: 37ecd3b8-9218-3bb9-a71b-a935b86f6a81</li>
+<li>introduced in DDNet 11.0.3, <a href="https://github.com/ddnet/ddnet/commit/1c3dc8c316c2bf37b94814d390c1c214422d46a9">1c3dc8c316c2bf37</a></li>
+</ul></li>
+<li>AUTH_LOGOUT(<a href="mailto:teehistorian-auth-logout@ddnet.tw">teehistorian-auth-logout@ddnet.tw</a>): cid(int) records that a player with cid just logged out of rcon
+<ul>
+<li>uuid: d4f5abe8-edd2-3fb9-abd8-1c8bb84f4a63</li>
+<li>introduced in DDNet 11.0.3, <a href="https://github.com/ddnet/ddnet/commit/1c3dc8c316c2bf37b94814d390c1c214422d46a9">1c3dc8c316c2bf37</a></li>
+</ul></li>
+<li>JOINVER6(<a href="mailto:teehistorian-joinver6@ddnet.tw">teehistorian-joinver6@ddnet.tw</a>): cid(int)
+<ul>
+<li>uuid: 1899a382-71e3-36da-937d-c9de6bb95b1d</li>
+<li>introduced in DDNet 14.0 <a href="https://github.com/ddnet/ddnet/commit/e294da41ba7142cb583a5dd2eab45af2ec9a8447">e294da41ba7142cb</a></li>
+</ul></li>
+<li>JOINVER7(<a href="mailto:teehistorian-joinver7@ddnet.tw">teehistorian-joinver7@ddnet.tw</a>): cid(int)
+<ul>
+<li>uuid: 59239b05-0540-318d-bea4-9aa1e80e7d2b</li>
+<li>introduced in DDNet 14.0 <a href="https://github.com/ddnet/ddnet/commit/e294da41ba7142cb583a5dd2eab45af2ec9a8447">e294da41ba7142cb</a></li>
+</ul></li>
+<li>TEAM_SAVE_SUCCESS(<a href="mailto:teehistorian-save-success@ddnet.tw">teehistorian-save-success@ddnet.tw</a>): team(int), save_id(uuid), save(str)
+<ul>
+<li>uuid: 4560c756-da29-3036-81d4-90a50f0182cd</li>
+<li>introduced in DDNet 14.0.2, <a href="https://github.com/ddnet/ddnet/commit/d8aab366fc8489c8cba4c77d73a6a7bfcce83bbc">d8aab366fc8489c8</a></li>
+</ul></li>
+<li>TEAM_SAVE_FAILURE(<a href="mailto:teehistorian-save-failure@ddnet.tw">teehistorian-save-failure@ddnet.tw</a>): team(int)
+<ul>
+<li>uuid: b29901d5-1244-3bd0-bbde-23d04b1f7ba9</li>
+<li>introduced in DDNet 14.0.2, <a href="https://github.com/ddnet/ddnet/commit/d8aab366fc8489c8cba4c77d73a6a7bfcce83bbc">d8aab366fc8489c8</a></li>
+</ul></li>
+<li>TEAM_LOAD_SUCCESS(<a href="mailto:teehistorian-load-success@ddnet.tw">teehistorian-load-success@ddnet.tw</a>): team(int), save_id(uuid), save(str)
+<ul>
+<li>uuid: e05408d3-a313-33df-9eb3-ddb990ab954a</li>
+<li>introduced in DDNet 14.0.2, <a href="https://github.com/ddnet/ddnet/commit/d8aab366fc8489c8cba4c77d73a6a7bfcce83bbc">d8aab366fc8489c8</a></li>
+</ul></li>
+<li>TEAM_LOAD_FAILURE(<a href="mailto:teehistorian-load-failure@ddnet.tw">teehistorian-load-failure@ddnet.tw</a>): team(int)
+<ul>
+<li>uuid: ef8905a2-c695-3591-a1cd-53d2015992dd</li>
+<li>introduced in DDNet 14.0.2, <a href="https://github.com/ddnet/ddnet/commit/d8aab366fc8489c8cba4c77d73a6a7bfcce83bbc">d8aab366fc8489c8</a></li>
+</ul></li>
+</ul>
+<p>The following data types are used:</p>
+<ul>
+<li>int is a <a href="int">teeworlds variable-width integer</a></li>
+<li>str is a null-terminated string</li>
+<li>raw[size] is simply size bytes</li>
+<li>str[num_args] is num_args null-terminated strings</li>
+<li>uuid is 16 bytes of a UUID</li>
+</ul>
+<p>the UUIDs are version 3 UUIDs, with the teeworlds namespace e05ddaaa-c4e6-4cfb-b642-5d48e80c0029 a tick is implicit in these messages when a player with lower cid is recorded using any of PLAYER_DIFF, PLAYER_NEW, PLAYER_OLD e.g. PLAYER_DIFF cid=0 … PLAYER_NEW cid=5 … PLAYER_OLD cid=3 has an implicit tick between the cid=5 and the cid=3 message another correction: the header is the teehistorian uuid followed by a zero-terminated string containing json in a self-explanatory format</p>
+</div>


### PR DESCRIPTION
If the libtw doc gets updated, running `./update_libtw2_doc.sh` (and committing the change) is sufficient to update the website.