### PR TITLE
Use external menu in libtw2 doc

### DIFF
--- a/update_libtw2_doc.sh
+++ b/update_libtw2_doc.sh
@@ -8,9 +8,8 @@ else
 	OUT_DIR="$1"
 fi
 
-INDEX="${OUT_DIR}/index.html"
-
 function file_names() {
+	# When adding/removing files, edit www/_data/menus.yml to update the menu
 	echo connection.md,Connection
 	echo datafile.md,Datafile
 	echo demo.md,Demo
@@ -25,17 +24,6 @@ function file_names() {
 	echo teehistorian.md,Teehistorian
 }
 
-function menu() {
-	echo "menu: |"
-	echo "  <ul>"
-	file_names | while read NAME TITLE
-	do
-		echo "    <li><a href=\"${URL}/${NAME/.md/}\">${TITLE}</a></li>"
-	done
-	echo "  </ul>"
-}
-
-
 function import_article() {
 	local REMOTE_NAME="$1"
 	local TITLE="$2"
@@ -43,7 +31,7 @@ function import_article() {
 	echo "---"
 	echo "title: \"${TITLE}\""
 	echo "layout: default"
-	menu
+	echo "menu-extern: docs-libtw2"
 	echo "---"
 	echo '<div id="global" class="block">'
 	echo ""
@@ -62,42 +50,11 @@ function import_article() {
 		| pandoc --from commonmark --to html \
 
 	echo '</div>'
-
-	# add a link to the index page
-	echo "  <li><a href=\"${REMOTE_NAME/.md/}\">${TITLE}</a></li>" >> $INDEX
-}
-
-function generate_index_pre() {
-	echo "---"
-	echo "title: \"Libtw2 doc\""
-	echo "layout: default"
-	menu
-	echo "---"
-	echo '<div id="global" class="block">'
-	echo ""
-	echo "<!-- This is an auto generated file. If you want to make changes edit scripts/import-twmap2-doc.sh instead -->"
-	echo ""
-	echo "<h2>Libtw2 doc</h2> "
-	echo '<small><i>'
-	echo 'This section is mirrored from the <a href="https://github.com/heinrich5991/libtw2">libtw2</a> documentation and is dual-licensed under MIT or APACHE.</i></small>'
-	echo '</i></small><br>'
-	echo ""
-	echo "Technical documentation of Teeworlds file formats and network protocol"
-	echo ""
-	echo "<ul>"
-}
-
-function generate_index_post() {
-	echo "</ul>"
-	echo "</div>"
 }
 
 mkdir -p "$OUT_DIR"
 
 IFS=','
-
-# regenerate index page
-generate_index_pre > $INDEX
 
 file_names | while read NAME TITLE
 do
@@ -106,6 +63,3 @@ do
 	echo "importing ${NAME} to ${FILENAME}"
 	import_article $NAME $TITLE > ${FILENAME}
 done
-
-generate_index_post >> $INDEX
-

--- a/www/_data/menus.yml
+++ b/www/_data/menus.yml
@@ -8,3 +8,19 @@ explain-layers: |
     <li><a href="/explain/switch">Switch layer</a></li>
     <li><a href="/explain/tune">Tune layer</a></li>
   </ul>
+
+docs-libtw2: |
+  <ul>
+    <li><a href="/docs/libtw2/connection">Connection</a></li>
+    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
+    <li><a href="/docs/libtw2/demo">Demo</a></li>
+    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
+    <li><a href="/docs/libtw2/int">Int</a></li>
+    <li><a href="/docs/libtw2/map">Map</a></li>
+    <li><a href="/docs/libtw2/packet">Packet</a></li>
+    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
+    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
+    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
+    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
+    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
+  </ul>

--- a/www/docs/libtw2/connection/index.html
+++ b/www/docs/libtw2/connection/index.html
@@ -1,21 +1,7 @@
 ---
 title: "Connection"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
 

--- a/www/docs/libtw2/datafile/index.html
+++ b/www/docs/libtw2/datafile/index.html
@@ -1,21 +1,7 @@
 ---
 title: "Datafile"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
 

--- a/www/docs/libtw2/demo/index.html
+++ b/www/docs/libtw2/demo/index.html
@@ -1,21 +1,7 @@
 ---
 title: "Demo"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
 

--- a/www/docs/libtw2/huffman/index.html
+++ b/www/docs/libtw2/huffman/index.html
@@ -1,21 +1,7 @@
 ---
 title: "Huffman"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
 

--- a/www/docs/libtw2/index.html
+++ b/www/docs/libtw2/index.html
@@ -1,25 +1,9 @@
 ---
 title: "Libtw2 doc"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
-
-<!-- This is an auto generated file. If you want to make changes edit scripts/import-twmap2-doc.sh instead -->
 
 <h2>Libtw2 doc</h2> 
 <small><i>
@@ -28,18 +12,6 @@ This section is mirrored from the <a href="https://github.com/heinrich5991/libtw
 
 Technical documentation of Teeworlds file formats and network protocol
 
-<ul>
-  <li><a href="connection">Connection</a></li>
-  <li><a href="datafile">Datafile</a></li>
-  <li><a href="demo">Demo</a></li>
-  <li><a href="huffman">Huffman</a></li>
-  <li><a href="int">Int</a></li>
-  <li><a href="map">Map</a></li>
-  <li><a href="packet">Packet</a></li>
-  <li><a href="packet7">Packet7</a></li>
-  <li><a href="quirks">Quirks</a></li>
-  <li><a href="serverinfo_extended">Serverinfo extended</a></li>
-  <li><a href="snapshot">Snapshot</a></li>
-  <li><a href="teehistorian">Teehistorian</a></li>
-</ul>
+{{ site.data.menus.docs-libtw2 | flatify }}
+
 </div>

--- a/www/docs/libtw2/int/index.html
+++ b/www/docs/libtw2/int/index.html
@@ -1,21 +1,7 @@
 ---
 title: "Int"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
 

--- a/www/docs/libtw2/map/index.html
+++ b/www/docs/libtw2/map/index.html
@@ -1,21 +1,7 @@
 ---
 title: "Map"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
 

--- a/www/docs/libtw2/packet/index.html
+++ b/www/docs/libtw2/packet/index.html
@@ -1,21 +1,7 @@
 ---
 title: "Packet"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
 

--- a/www/docs/libtw2/packet7/index.html
+++ b/www/docs/libtw2/packet7/index.html
@@ -1,21 +1,7 @@
 ---
 title: "Packet7"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
 

--- a/www/docs/libtw2/quirks/index.html
+++ b/www/docs/libtw2/quirks/index.html
@@ -1,21 +1,7 @@
 ---
 title: "Quirks"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
 

--- a/www/docs/libtw2/serverinfo_extended/index.html
+++ b/www/docs/libtw2/serverinfo_extended/index.html
@@ -1,21 +1,7 @@
 ---
 title: "Serverinfo extended"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
 

--- a/www/docs/libtw2/snapshot/index.html
+++ b/www/docs/libtw2/snapshot/index.html
@@ -1,21 +1,7 @@
 ---
 title: "Snapshot"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
 

--- a/www/docs/libtw2/teehistorian/index.html
+++ b/www/docs/libtw2/teehistorian/index.html
@@ -1,21 +1,7 @@
 ---
 title: "Teehistorian"
 layout: default
-menu: |
-  <ul>
-    <li><a href="/docs/libtw2/connection">Connection</a></li>
-    <li><a href="/docs/libtw2/datafile">Datafile</a></li>
-    <li><a href="/docs/libtw2/demo">Demo</a></li>
-    <li><a href="/docs/libtw2/huffman">Huffman</a></li>
-    <li><a href="/docs/libtw2/int">Int</a></li>
-    <li><a href="/docs/libtw2/map">Map</a></li>
-    <li><a href="/docs/libtw2/packet">Packet</a></li>
-    <li><a href="/docs/libtw2/packet7">Packet7</a></li>
-    <li><a href="/docs/libtw2/quirks">Quirks</a></li>
-    <li><a href="/docs/libtw2/serverinfo_extended">Serverinfo extended</a></li>
-    <li><a href="/docs/libtw2/snapshot">Snapshot</a></li>
-    <li><a href="/docs/libtw2/teehistorian">Teehistorian</a></li>
-  </ul>
+menu-extern: docs-libtw2
 ---
 <div id="global" class="block">
 

--- a/www/explain/front/index.html
+++ b/www/explain/front/index.html
@@ -14,3 +14,5 @@ menu-extern: explain-layers
 
 <p>This work, "<a href="/explain/front.svg">Front layer</a>", is a derivative of "<a href="https://github.com/ddnet/ddnet/blob/master/data/editor/front.png">front.png</a>", used under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>. "Front layer" by Patiga and Zwelf is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>
 <p>Idea and previous implementation by Lady Saavik (explanations) and Soreu, timakro (code)</p>
+
+</div>

--- a/www/explain/game/index.html
+++ b/www/explain/game/index.html
@@ -14,3 +14,5 @@ menu-extern: explain-layers
 
 <p>This work, "<a href="/explain/game.svg">Game layer</a>", is a derivative of "<a href="https://github.com/ddnet/ddnet/blob/master/data/editor/entities/DDNet.png">game.png</a>", used under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>. "Game layer" by Patiga and Zwelf is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>
 <p>Idea and previous implementation by Lady Saavik (explanations) and Soreu, timakro (code)</p>
+
+</div>

--- a/www/explain/index.html
+++ b/www/explain/index.html
@@ -14,3 +14,5 @@ menu-extern: explain-layers
 
 <p>This work, "<a href="/explain/entities.svg">Entities overlay</a>", is a derivative of "<a href="https://github.com/ddnet/ddnet/blob/master/data/editor/entities_clear/ddnet.png">entities_clear</a>", used under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>. "Entities overlay" by Patiga and Zwelf is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>
 <p>Idea and previous implementation by Lady Saavik (explanations) and Soreu, timakro (code)</p>
+
+</div>

--- a/www/explain/speedup/index.html
+++ b/www/explain/speedup/index.html
@@ -14,3 +14,5 @@ menu-extern: explain-layers
 
 <p>This work, "<a href="/explain/speedup.svg">Speedup layer</a>", is a derivative of "<a href="https://github.com/ddnet/ddnet/blob/master/data/editor/speedup.png">speedup.png</a>", used under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>. "Front layer" by Patiga and Zwelf is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>
 <p>Idea and previous implementation by Lady Saavik (explanations) and Soreu, timakro (code)</p>
+
+</div>

--- a/www/explain/switch/index.html
+++ b/www/explain/switch/index.html
@@ -14,3 +14,5 @@ menu-extern: explain-layers
 
 <p>This work, "<a href="/explain/switch.svg">Switch layer</a>", is a derivative of "<a href="https://github.com/ddnet/ddnet/blob/master/data/editor/switch.png">switch.png</a>", used under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>. "Switch layer" by Patiga and Zwelf is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>
 <p>Idea and previous implementation by Lady Saavik (explanations) and Soreu, timakro (code)</p>
+
+</div>

--- a/www/explain/tele/index.html
+++ b/www/explain/tele/index.html
@@ -14,3 +14,5 @@ menu-extern: explain-layers
 
 <p>This work, "<a href="/explain/tele.svg">Tele layer</a>", is a derivative of "<a href="https://github.com/ddnet/ddnet/blob/master/data/editor/tele.png">tele.png</a>", used under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>. "Tele layer" by Patiga and Zwelf is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>
 <p>Idea and previous implementation by Lady Saavik (explanations) and Soreu, timakro (code)</p>
+
+</div>

--- a/www/explain/tune/index.html
+++ b/www/explain/tune/index.html
@@ -14,3 +14,5 @@ menu-extern: explain-layers
 
 <p>This work, "<a href="/explain/tune.svg">Tune layer</a>", is a derivative of "<a href="https://github.com/ddnet/ddnet/blob/master/data/editor/tune.png">tune.png</a>", used under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>. "Tune layer" by Patiga and Zwelf is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>
 <p>Idea and previous implementation by Lady Saavik (explanations) and Soreu, timakro (code)</p>
+
+</div>


### PR DESCRIPTION
With this, adding another page in the doc, doesn't change all pages in `docs/libtw2`.

Unrelated change: Add missing `</div>` in the explain pages.