### PR TITLE
add flex container, used in map releases

### DIFF
--- a/www/css.css
+++ b/www/css.css
@@ -1050,3 +1050,10 @@ body#phpbb .attachbox dl.thumbnail a::after {
   height: 100%;
   background-color: transparent;
 }
+
+.flex-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  justify-content: space-around;
+}


### PR DESCRIPTION
Needs https://github.com/ddnet/ddnet-scripts/pull/37

It uses flexbox so that the map releases page doesnt look bad on mobile devices and improves responsiveness.