### PR TITLE
Add .well-known files for :ddnet.org matrix server

### DIFF
--- a/www/.well-known/matrix/client
+++ b/www/.well-known/matrix/client
@@ -1,0 +1,1 @@
+{"m.homeserver": {"base_url": "https://matrix.ddnet.org"}}

--- a/www/.well-known/matrix/server
+++ b/www/.well-known/matrix/server
@@ -1,0 +1,1 @@
+{"m.server": "matrix.ddnet.org:443"}

--- a/www/_config.yml
+++ b/www/_config.yml
@@ -4,3 +4,4 @@ markdown: kramdown
 highlighter: true
 author:
   name: deen
+include: [".well-known"]


### PR DESCRIPTION
dns entries for matrix.ddnet.org would still be necessary.