### PR TITLE
Remove redundant styles, some fixes

### DIFF
--- a/www/css.css
+++ b/www/css.css
@@ -662,7 +662,7 @@ body:not(#phpbb) .time {
   width: 80%;
 }
 
-.progress {
+.progress, .progressbar {
   background-image: linear-gradient(to bottom, #ddd 0%, #eee 100%);
 }
 

--- a/www/css.css
+++ b/www/css.css
@@ -597,6 +597,7 @@ body:not(#phpbb) .time {
   width: 255px;
 }
 .tt-suggestion {
+  cursor: pointer;
   font-size: 88%;
   line-height: 18px;
   padding: 3px 10px;
@@ -659,6 +660,10 @@ body:not(#phpbb) .time {
 
 .funding-bar {
   width: 80%;
+}
+
+.progress {
+  background-image: linear-gradient(to bottom, #ddd 0%, #eee 100%);
 }
 
 .progressbar {

--- a/www/css.css
+++ b/www/css.css
@@ -9,12 +9,14 @@
 :root {
   --bg: #d8efff;
   --bg-block: #ffffff;
+  --fg: black;
   --link: #882222;
 }
 
 html,
 body {
   background-color: var(--bg);
+  color: var(--fg);
   font-family: sans-serif;
   margin: 0;
   padding: 0;
@@ -92,11 +94,6 @@ body:not(#phpbb) .block {
   background-color: #00000012;
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
-}
-
-body:not(#phpbb) code {
-  background-color: #00000012;
-  border-radius: 5px;
 }
 
 body:not(#phpbb) pre {
@@ -478,6 +475,10 @@ br {
   text-align: center;
 }
 
+.highcharts-container svg g.highcharts-button * {
+  cursor: pointer;
+}
+
 .spacey td {
   padding: 0 1em;
 }
@@ -783,6 +784,7 @@ body:not(#phpbb) .time {
     margin-left: 0em;
     border-right: 3px solid #ffd246;
     transition-property: border-right-color;
+    z-index: 1;
   }
 
   .contentleft ul {

--- a/www/css/css-halloween.css
+++ b/www/css/css-halloween.css
@@ -182,7 +182,7 @@ body:not(#phpbb) pre code {
 
 .highcharts-container svg g.highcharts-button rect {
   fill: #ffffff;
-  stroke: #f07141;
+  stroke: none;
 }
 .highcharts-contextmenu ul {
   border: 1px solid rgba(0, 0, 0, 0.2) !important;

--- a/www/css/css-halloween.css
+++ b/www/css/css-halloween.css
@@ -184,21 +184,22 @@ body:not(#phpbb) pre code {
   fill: #ffffff;
   stroke: #f07141;
 }
-.highcharts-contextmenu div {
+.highcharts-contextmenu ul {
   border: 1px solid rgba(0, 0, 0, 0.2) !important;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2) !important;
   background: #333333 !important;
   color: #c8c8c8 !important;
 }
-.highcharts-contextmenu div div {
+.highcharts-contextmenu ul li {
   border: none !important;
   box-shadow: none !important;
+  color: #c8c8c8 !important;
 }
-.highcharts-contextmenu div div:hover {
+.highcharts-contextmenu ul li:hover {
   background-color: #f07141 !important;
   color: #000000 !important;
 }
-.highcharts-contextmenu div hr {
+.highcharts-contextmenu ul hr {
   border: 1px solid rgba(0, 0, 0, 0.2);
 }
 

--- a/www/css/css-halloween.css
+++ b/www/css/css-halloween.css
@@ -7,12 +7,6 @@
   --bg-block: #555555;
 }
 
-html,
-body {
-  background: var(--bg);
-  color: var(--fg);
-}
-
 .js-calendar-graph-svg {
   fill: var(--fg);
 }
@@ -59,7 +53,7 @@ a:hover {
 section .block,
 section .longblock {
   background: #555555;
-  border: 1px solid rgba(0, 0, 0, 0.5);
+  border-color: rgba(0, 0, 0, 0.5);
   box-shadow: 0px 0px 10px 5px rgba(0, 0, 0, 0.5);
 }
 
@@ -74,12 +68,7 @@ section .longblock {
 }
 
 .news blockquote {
-  border-left: 10px solid var(--link);
-  margin: 1.5em 0px;
-  padding: 0.5em 10px;
   background-color: #4d4d4d;
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
 }
 
 .ui-widget-content {
@@ -89,7 +78,7 @@ section .longblock {
 }
 
 .settingscommands tr {
-  border-bottom: 1px solid #222222;
+  border-bottom-color: #222222;
 }
 
 body:not(#phpbb) code {
@@ -99,13 +88,10 @@ body:not(#phpbb) code {
 
 body:not(#phpbb) pre {
   background-color: rgba(0, 0, 0, 0.2);
-  border-radius: 5px;
-  padding: 5px;
 }
 
 body:not(#phpbb) pre code {
   background-color: transparent;
-  padding: 0;
 }
 
 /* ========================= Status ========================= */
@@ -132,7 +118,7 @@ body:not(#phpbb) pre code {
 
 /* ========================= Ranks ========================= */
 .typeahead:focus {
-  border: 2px solid #f07141;
+  border-color: #f07141;
 }
 .tt-dropdown-menu {
   background-color: rgba(0, 0, 0, 0.4);
@@ -159,7 +145,7 @@ body:not(#phpbb) pre code {
 }
 .unfinTable2,
 .unfinTable3 {
-  border-left: 1px solid rgba(0, 0, 0, 0.75) !important;
+  border-left-color: rgba(0, 0, 0, 0.75);
 }
 .unfinTable2 thead,
 .unfinTable3 thead {
@@ -180,7 +166,7 @@ body:not(#phpbb) pre code {
 .unfinTable1 td:not(:last-child),
 .unfinTable2 td:not(:last-child),
 .unfinTable3 td:not(:last-child) {
-  border-right: 1px solid rgba(0, 0, 0, 0.3) !important;
+  border-right-color: rgba(0, 0, 0, 0.3) !important;
 }
 
 /* ========================= Statistics ========================= */
@@ -197,9 +183,6 @@ body:not(#phpbb) pre code {
 .highcharts-container svg g.highcharts-button rect {
   fill: #ffffff;
   stroke: #f07141;
-}
-.highcharts-container svg g.highcharts-button * {
-  cursor: pointer;
 }
 .highcharts-contextmenu div {
   border: 1px solid rgba(0, 0, 0, 0.2) !important;

--- a/www/css/css-halloween.css
+++ b/www/css/css-halloween.css
@@ -111,17 +111,13 @@ body:not(#phpbb) pre code {
 .table > tfoot > tr > td {
   border-top: 1px solid #222222;
 }
-.progress {
-  background-color: rgba(255, 255, 255, 0.4);
-  background-image: none;
-}
 
 /* ========================= Ranks ========================= */
 .typeahead:focus {
   border-color: #f07141;
 }
 .tt-dropdown-menu {
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: #333333cc;
 }
 .tt-suggestion.tt-cursor {
   background-color: #f07141;

--- a/www/css/css-halloween.css
+++ b/www/css/css-halloween.css
@@ -208,6 +208,11 @@ body:not(#phpbb) pre code {
   stroke: #222222;
 }
 
+.highcharts-range-selector {
+  background: #555555;
+  color: #cccccc;
+}
+
 .highcharts-container svg g.highcharts-axis-labels text {
   color: #cccccc !important;
   fill: #cccccc !important;

--- a/www/playersearch.js
+++ b/www/playersearch.js
@@ -2,12 +2,12 @@ var players = new Bloodhound({
   datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name'),
   queryTokenizer: Bloodhound.tokenizers.whitespace,
   remote: '/players/?query=%QUERY',
-  limit: 10
+  limit: 12
 });
 
 players.initialize();
 
-$('#playerform .typeahead').typeahead(null, {
+const typeaheadDataset = {
   name: 'players',
   displayKey: 'name',
   source: players.ttAdapter(),
@@ -16,6 +16,12 @@ $('#playerform .typeahead').typeahead(null, {
       return '<p><strong>' + o.name.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;") + '</strong><span class="right">' + o.points + '&nbsp;points</span></p>'
     }
   }
-}).on('typeahead:selected', function(e, data) {
+};
+
+$('#playerform .typeahead').typeahead(null, typeaheadDataset).on('typeahead:selected', function(e, data) {
   $('#playerform').submit();
+});
+
+$('#playerform2 .typeahead').typeahead(null, typeaheadDataset).on('typeahead:selected', function(e, data) {
+  $('#playerform2').submit();
 });


### PR DESCRIPTION
Various style fixes, such as:
- orange border removed from non-orange component
- proper dark styles for third-party components (such styles were attempted by the original theme author but stopped applying due to differences in the theme's markup)
- unifying the progress bar colors on all pages (dark theme's progress bar backgrounds looked odd to me, especially considering the text contrast. they are now the same as light theme including the funding page, being off-white and easier on the eyes)
- hopefully fix the "Compare player" input auto-completion (needs to be tested)