### PR TITLE
Setup Master Server Rules Page

### DIFF
--- a/www/rules/master/index.html
+++ b/www/rules/master/index.html
@@ -1,0 +1,60 @@
+---
+layout: default
+title: Master Server Rules - DDraceNetwork
+menu: |
+  <ul>
+    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
+    <li><a href="/server/">Server&nbsp;Features</a></li>
+    <li><a href="/client/">Client&nbsp;Features</a></li>
+    <li><a href="/map/">Map&nbsp;Features</a></li>
+    <li><a href="/howto/">How&nbsp;to&nbsp;Map</a></li>
+    <li><a href="/rules/">Mapping&nbsp;Rules</a> / <a href="/guidelines/">Guidelines</a></li>
+    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
+    <li><a href="/auto-font/">Auto-Font</a></li>
+    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
+    <li><a href="/renames/">Renames</a></li>
+    <li><a href="/funding/">Funding</a></li>
+  </ul>
+---
+<div class="block">
+  <h2 id="master-rules">Master Server Rules</h2>
+  <p>Some rules has been directly adopted from teeworlds.com:</p>
+  <ol>
+    <li>Modified servers should not use standard gametypes (e.g., dm, tdm, ctf, lms, lts).</li>
+    <li>The player count shown should accurately reflect the number of human players. The maximum player count must indicate the total number of human players that can join.</li>
+    <li>Do not host an excessive amount of servers. There is no fixed limit but try to not overdo it. (i.e. there should be people playing on them eventually)</li>
+    <li>Do not host servers purely for advertising purposes (e.g., password-protected servers just for ads). However, including sponsor information or similar details in the server name is fine.</li>
+  </ol>
+  <p>Additionally, the following rules apply:</p>
+  <ol start="5">
+    <li>The Server must be joinable via the official DDNet client without requiring a custom client.</li>
+    <li>Servers with inappropriate content, like maps containing nudity, are strictly prohibited.</li>
+    <li>Do not host public servers that encourage or facilitate cheating, including servers meant exclusively for TAS runs.</li>
+    <li>Server names must be unique and should not impersonate or duplicate existing servers.</li>
+    <li>If the server requires account creation and login to play, the <code>requires_login</code> property must be set to <code>True</code> (refer to <a href="https://github.com/ddnet/ddnet/blob/282ea709427b2569ffc66422b8c04b28a9708f9a/src/engine/server/server.cpp#L2507">server.cpp</a>).</li>
+  </ol>
+  <p>This list is not <strong>exhaustive</strong>. Additional rules may be applied <strong>retrospectively</strong> at our discretion, including banning servers that violate the spirit of fair play or good conduct.</p>
+  <p>You can check out the list of master server bans <a href="https://teeworlds.com/master-bans.cfg">here</a> if you have any doubts. If you wish to be notified about issues with your server(s), provide a contact email address in your MOTD or contact us on the official <a href="/discord/">Discord</a> server.</p>
+</div>
+<div class="block">
+    <h2 id="master-bans">Current Master bans</h2>
+	<pre><code>bans = [
+            { address = "44.204.219.193" }, # VIOLATING 3. & 4.
+            { address = "45.9.5.233" }, # VIOLATING 2. & 4.
+            { address = "158.101.168.19" }, # VIOLATING 9.
+            { address = "185.16.61.186" }, # VIOLATING 9.
+            { address = "185.16.61.186" }, # VIOLATING 9.
+            { address = "185.103.101.182" }, # VIOLATING 9.
+            { address = "37.221.67.9" }, # VIOLATING 9.
+            { address = "193.164.4.232" }, # VIOLATING 2.
+            { address = "146.19.196.222" }, # VIOLATING 9.
+            { address = "2408:8352:c200:1951:a58f:9a1b:292c:7f7e" }, # VIOLATING 8.
+            { address = "45.131.108.142" }, # VIOLATING 4. & 7.
+            { address = "45.150.149.162" },
+            { address = "45.150.149.157" },
+            { address = "45.90.218.105" }, # VIOLATING 9.
+            { address = "82.202.170.34" }, # VIOLATING 2.
+            { address = "2408:8000::/18" }, # VIOLATING 8.
+            { address = "8.137.0.0/17" }, # VIOLATING 8.
+	</code></pre>
+</div>


### PR DESCRIPTION
Supersedes #298

> @heinrich5991 Can the master bans be moved to it's own file, so I can include it part of the master-server rules webpage? 
Otherwise I can just copy paste the banlist from the file, but requires manual edits in the ddnet-web repo everytime we add a new server to it.
