### PR TITLE
DDNet 19.1

### DIFF
--- a/www/downloads/index.html
+++ b/www/downloads/index.html
@@ -4,6 +4,82 @@ title: Downloads - DDraceNetwork
 ---
 <div class="block">
 <h2 id="downloads">Downloads</h2>
+<h3 id="19.1"><a href="#19.1">DDNet 19.1</a></h3>
+<div class="dlfiles">
+  2025-03-29<br/><br/>
+  <ul>
+    <li><a href="DDNet-19.1-win64.zip">Windows&nbsp;64bit</a></li>
+    <li><a href="DDNet-19.1-win-arm64.zip">Windows&nbsp;ARM</a></li>
+    <li><a href="DDNet-19.1-win32.zip">Windows&nbsp;32bit</a></li>
+    <li><a href="DDNet-19.1-linux_x86.tar.xz">Linux&nbsp;x86</a></li>
+    <li><a href="DDNet-19.1-linux_x86_64.tar.xz">Linux&nbsp;x86-64</a></li>
+    <li><a href="DDNet-19.1-macos.dmg">macOS (arm64&nbsp;&amp;&nbsp;x86-64)</a></li>
+    <li><a href="DDNet-19.1.apk">Android</a></li>
+    <li><a href="DDNet-19.1.tar.xz">Source</a></li>
+  </ul>
+</div>
+<div class="dlinfo">
+  <strong>Changelog</strong>
+  <ul>
+    <li>[Client] <strong>Nameplate rewrite</strong> [<strong>SollyBunny</strong>]</li>
+    <li>[Editor] <strong>New speed tiles</strong> [<strong>AssassinTee</strong>]</li>
+    <li>[Client] Overhaul skin loading and refreshing, improvements for 0.7 skins [<strong>Robyt3</strong>]</li>
+    <li>[Client] Move DDRace HUD title to correct pane [<strong>SollyBunny</strong>]</li>
+    <li>[Client] Always automatically rcon auth on local server [<strong>KebsCS</strong>]</li>
+    <li>[Client] Add size to demo list [<strong>KebsCS</strong>]</li>
+    <li>[Client] Allow test map locally in subfolders [<strong>KebsCS</strong>]</li>
+    <li>[Client] Apply alpha to spectating tees from other teams [<strong>Pioooooo</strong>]</li>
+    <li>[Client] Slider to change prediction margin [<strong>dropalways</strong>]</li>
+    <li>[Client] Changes to mouse button press handling [<strong>KebsCS</strong>]</li>
+    <li>[Client] Reduce FPS impact of community icon loading [<strong>Robyt3</strong>]</li>
+    <li>[Client] Fix incorrect chat messages for inactive client [<strong>Robyt3</strong>]</li>
+    <li>[Client] Android: Support importing touch controls with no "label-type" [<strong>K1nop1c0</strong>]</li>
+    <li>[Client] Fix spectator cursor on older servers [<strong>furo321</strong>]</li>
+    <li>[Client] Fix player_default_eyes not working if cl_run_on_join ends with ; [<strong>furo321</strong>]</li>
+    <li>[Client] Support using dbg_graphs without debug [<strong>Robyt3</strong>]</li>
+    <li>[Client] Fix left and right joystick hat keys [<strong>Robyt3</strong>]</li>
+    <li>[Client] Fix camera button overlap the "record demo button" in vanilla [<strong>StormAxs</strong>]</li>
+    <li>[Client] Clear key states on alt tab [<strong>KebsCS</strong>]</li>
+    <li>[Client] Improve HiDPI handling [<strong>Patiga &amp; Jupeyy</strong>]</li>
+    <li>[Client] Fix crash due to changed sound sample assertion [<strong>Robyt3</strong>]</li>
+    <li>[Editor] Add flip and rotate to speedup arrow angle  [<strong>KebsCS</strong>]</li>
+    <li>[Editor] Make "Allow all unknown settings" allow all settings [<strong>KebsCS</strong>]</li>
+    <li>[Editor] Add shift+scroll to speedup layer [<strong>KebsCS</strong>]</li>
+    <li>[Editor] Fix unused tele/speedup tiles deleting with shift fill mode [<strong>ZerolAcqua</strong>]</li>
+    <li>[Editor] Fix automap refernece popup initial selection [<strong>Robyt3</strong>]</li>
+    <li>[Editor] Fix automapper seed crash [<strong>KebsCS</strong>]</li>
+    <li>[Editor] Fix automapper undo and popup crashes [<strong>KebsCS</strong>]</li>
+    <li>[Editor] Improve editor tune popup and tune tile text render [<strong>KebsCS</strong>]</li>
+    <li>[Editor] Fix undo for hookthrough's front layer [<strong>KebsCS</strong>]</li>
+    <li>[Server&amp;Client] Make fifo commands usable from console [<strong>MilkeeyCat</strong>]</li>
+    <li>[Server] Reset velocity when using move commands [<strong>SoulyVEVO</strong>]</li>
+    <li>[Server] Fix unpractice when locked [<strong>KebsCS</strong>]</li>
+    <li>[Server] Fix jetpack tuning and incorrect tune zone override [<strong>KebsCS</strong>]</li>
+    <li>[Server] Error in auth_add when username is too long [<strong>Robyt3</strong>]</li>
+    <li>[Server] Disable spectator count for hide_auth_status [<strong>KebsCS</strong>]</li>
+    <li>[Server] Fix keeping spec [<strong>KebsCS</strong>]</li>
+    <li>[Server] Don't unpause when force pause timer is over [<strong>furo321</strong>]</li>
+  </ul>
+  and a lot of smaller fixes, see the <a href="https://github.com/ddnet/ddnet/compare/19.0...19.1">full list of git changes</a>
+</div>
+<br/>
+<h3>Other Downloads</h3>
+<ul>
+  <li><a href="https://store.steampowered.com/app/412220/DDraceNetwork/">Steam package</a></li>
+  <li><a href="https://flathub.org/apps/tw.ddnet.ddnet">Flatpak package</a></li>
+  <li><a href="https://packages.debian.org/search?keywords=ddnet">Debian packages</a></li>
+  <li><a href="https://packages.ubuntu.com/search?keywords=ddnet&searchon=names&section=all">Ubuntu packages</a></li>
+  <li><a href="https://aur.archlinux.org/packages/?O=0&SeB=nd&K=ddnet&outdated=&SB=n&SO=a&PP=50&do_Search=Go">ArchLinux AUR packages</a>, <a href="https://wiki.archlinux.org/index.php/DDRaceNetwork">ArchWiki</a></li>
+  <li id="nightly-builds">Nightly Builds: <a href="DDNet-nightly-win64.zip">Windows&nbsp;64bit</a>, <a href="DDNet-nightly-win-arm64.zip">Windows&nbsp;ARM</a>, <a href="DDNet-nightly-win32.zip">Windows&nbsp;32bit</a>, <a href="DDNet-nightly-linux_x86.tar.xz">Linux&nbsp;x86</a>, <a href="DDNet-nightly-linux_x86_64.tar.xz">Linux&nbsp;x86-64</a>, <a href="DDNet-nightly-macos.dmg">macOS</a>, <a href="DDNet-nightly.apk">Android</a> (<a href="DDNet-nightly.log">build log</a>)</li>
+  <li>Hashes for download verification: <a href="sha256sums.txt">SHA256</a></li>
+  <li>Git repositories: <a href="https://github.com/ddnet/ddnet">DDNet Client &amp; Server</a>, <a href="https://github.com/ddnet/ddnet-maps">Maps</a> (including configs, <a href="https://github.com/ddnet/ddnet-maps/archive/master.zip">download all maps</a>), <a href="https://github.com/ddnet/ddnet-scripts">Scripts</a>, <a href="https://github.com/ddnet/ddnet-libs">Libs</a></li>
+  <li>Raw list of all DDNet ranks, team ranks and maps: <a href="/stats/ddnet-stats.zip">CSV</a>, <a href="/stats/ddnet-sql.zip">SQL</a></li>
+  <li>Map download server: <a href="https://maps.ddnet.org/">List of all maps</a>, <a href="https://maps.ddnet.org/compilations/">Map compilations</a></li>
+  <li><a href="http://www.foveon.de/sonstiges/opusdrop/index.htm">OpusDrop</a> (Convert sound files to Opus for DDNet maps)</li>
+</ul>
+</div>
+<div class="block">
+<h2 id="old-downloads">Old Versions</h2>
 <h3 id="19.0"><a href="#19.0">DDNet 19.0</a></h3>
 <div class="dlfiles">
   2025-02-26<br/><br/>
@@ -74,24 +150,6 @@ title: Downloads - DDraceNetwork
   </ul>
   and a lot of smaller fixes, see the <a href="https://github.com/ddnet/ddnet/compare/18.9.1...19.0">full list of git changes</a>
 </div>
-<br/>
-<h3>Other Downloads</h3>
-<ul>
-  <li><a href="https://store.steampowered.com/app/412220/DDraceNetwork/">Steam package</a></li>
-  <li><a href="https://flathub.org/apps/tw.ddnet.ddnet">Flatpak package</a></li>
-  <li><a href="https://packages.debian.org/search?keywords=ddnet">Debian packages</a></li>
-  <li><a href="https://packages.ubuntu.com/search?keywords=ddnet&searchon=names&section=all">Ubuntu packages</a></li>
-  <li><a href="https://aur.archlinux.org/packages/?O=0&SeB=nd&K=ddnet&outdated=&SB=n&SO=a&PP=50&do_Search=Go">ArchLinux AUR packages</a>, <a href="https://wiki.archlinux.org/index.php/DDRaceNetwork">ArchWiki</a></li>
-  <li id="nightly-builds">Nightly Builds: <a href="DDNet-nightly-win64.zip">Windows&nbsp;64bit</a>, <a href="DDNet-nightly-win-arm64.zip">Windows&nbsp;ARM</a>, <a href="DDNet-nightly-win32.zip">Windows&nbsp;32bit</a>, <a href="DDNet-nightly-linux_x86.tar.xz">Linux&nbsp;x86</a>, <a href="DDNet-nightly-linux_x86_64.tar.xz">Linux&nbsp;x86-64</a>, <a href="DDNet-nightly-macos.dmg">macOS</a>, <a href="DDNet-nightly.apk">Android</a> (<a href="DDNet-nightly.log">build log</a>)</li>
-  <li>Hashes for download verification: <a href="sha256sums.txt">SHA256</a></li>
-  <li>Git repositories: <a href="https://github.com/ddnet/ddnet">DDNet Client &amp; Server</a>, <a href="https://github.com/ddnet/ddnet-maps">Maps</a> (including configs, <a href="https://github.com/ddnet/ddnet-maps/archive/master.zip">download all maps</a>), <a href="https://github.com/ddnet/ddnet-scripts">Scripts</a>, <a href="https://github.com/ddnet/ddnet-libs">Libs</a></li>
-  <li>Raw list of all DDNet ranks, team ranks and maps: <a href="/stats/ddnet-stats.zip">CSV</a>, <a href="/stats/ddnet-sql.zip">SQL</a></li>
-  <li>Map download server: <a href="https://maps.ddnet.org/">List of all maps</a>, <a href="https://maps.ddnet.org/compilations/">Map compilations</a></li>
-  <li><a href="http://www.foveon.de/sonstiges/opusdrop/index.htm">OpusDrop</a> (Convert sound files to Opus for DDNet maps)</li>
-</ul>
-</div>
-<div class="block">
-<h2 id="old-downloads">Old Versions</h2>
 <h3 id="18.9"><a href="#18.9">DDNet 18.9.1</a></h3>
 <div class="dlfiles">
   2025-01-26<br/><br/>

--- a/www/index.php
+++ b/www/index.php
@@ -76,7 +76,7 @@ function getOS() {
 }
 
 $user_os = getOS();
-$version = '19.0';
+$version = '19.1';
 
 if ($user_os == 'win32') {
   print '<p class="download"><span class="big"><a href="/downloads/DDNet-' . $version . '-win32.zip">Download DDraceNetwork Client &amp; Server ' . $version . ' for Windows (32bit)</a></span><br/><a href="/downloads/">Other systems and versions, changelogs</a></p>';


### PR DESCRIPTION
DDNet 19.1 is scheduled to release in 7 days, assuming no bad bugs are found. Please test the Release Candidate to prevent problems being only discovered after release. Report bugs in the #bugs channel on DDNet Discord or directly on Github:

- Windows 64bit: https://ddnet.org/downloads/DDNet-19.1-rc1-win64.zip
- Windows ARM: https://ddnet.org/downloads/DDNet-19.1-rc1-win-arm64.zip
- Windows 32bit: https://ddnet.org/downloads/DDNet-19.1-rc1-win32.zip
- Linux x86: https://ddnet.org/downloads/DDNet-19.1-rc1-linux_x86.tar.xz
- Linux x86-64: https://ddnet.org/downloads/DDNet-19.1-rc1-linux_x86_64.tar.xz
- macOS: https://ddnet.org/downloads/DDNet-19.1-rc1-macos.dmg
- Android: https://ddnet.org/downloads/DDNet-19.1-rc1.apk

You can also test the release candidate in Steam by clicking on Settings -> Properties -> Betas and opting into the Release Candidates. This will automatically update you to a new release candidate when it is available, and to the next release when no new candidate is available. So you can always leave this setting enabled to help us test new releases earlier.

The following changes are included, ideally test their behavior specifically. But just playing as you do normally also helps:

- [Client] **Add spectator count to HUD** [KebsCS]
- [Client] **Nameplate rewrite** [SollyBunny]
- [Editor] **New speed tiles** [AssassinTee]
- [Client] Overhaul skin loading and refreshing, improvements for 0.7 skins [Robyt3]
- [Client] Move DDRace HUD title to correct pane [SollyBunny]
- [Client] Always automatically rcon auth on local server [KebsCS]
- [Client] Add size to demo list [KebsCS]
- [Client] Allow test map locally in subfolders [KebsCS]
- [Client] Apply alpha to spectating tees from other teams [Pioooooo]
- [Client] Slider to change prediction margin [dropalways]
- [Client] Changes to mouse button press handling [KebsCS]
- [Client] Reduce FPS impact of community icon loading [Robyt3]
- [Client] Fix incorrect chat messages for inactive client [Robyt3]
- [Client] Android: Support importing touch controls with no "label-type" [K1nop1c0]
- [Client] Fix spectator cursor on older servers [furo321]
- [Client] Fix player_default_eyes not working if cl_run_on_join ends with ; [furo321]
- [Client] Support using dbg_graphs without debug [Robyt3]
- [Client] Fix left and right joystick hat keys [Robyt3]
- [Client] Fix camera button overlap the "record demo button" in vanilla [StormAxs]
- [Client] Clear key states on alt tab [KebsCS]
- [Client] Improve HiDPI handling [Patiga & Jupeyy]
- [Client] Fix crash due to changed sound sample assertion [Robyt3]
- [Editor] Add flip and rotate to speedup arrow angle [KebsCS]
- [Editor] Make "Allow all unknown settings" allow all settings [KebsCS]
- [Editor] Add shift+scroll to speedup layer [KebsCS]
- [Editor] Fix unused tele/speedup tiles deleting with shift fill mode [ZerolAcqua]
- [Editor] Fix automap refernece popup initial selection [Robyt3]
- [Editor] Fix automapper seed crash [KebsCS]
- [Editor] Fix automapper undo and popup crashes [KebsCS]
- [Editor] Improve editor tune popup and tune tile text render [KebsCS]
- [Editor] Fix undo for hookthrough's front layer [KebsCS]
- [Server&Client] Make fifo commands usable from console [MilkeeyCat]
- [Server] Reset velocity when using move commands [SoulyVEVO]
- [Server] Fix unpractice when locked [KebsCS]
- [Server] Fix jetpack tuning and incorrect tune zone override [KebsCS]
- [Server] Error in auth_add when username is too long [Robyt3]
- [Server] Disable spectator count for hide_auth_status [KebsCS]
- [Server] Fix keeping spec [KebsCS]
- [Server] Don't unpause when force pause timer is over [furo321]