### PR TITLE
Clarify community rule regarding monetary rewards

### DIFF
--- a/www/rules/community/index.html
+++ b/www/rules/community/index.html
@@ -34,7 +34,10 @@ menu: |
       <p>Servers and staff must maintain a friendly and SFW atmosphere:</p>
       <ol type="a">
         <li>DDNet has an age rating of <em>6 years (fantasy violence)</em> on <a href="https://store.steampowered.com/app/412220/DDNet/">Steam</a>, which must also apply to every official community.</li>
-        <li>Any monetary reward systems are prohibited. Accepting donations is allowed, as long as there are no differences in gameplay between donors and non-donors. Listing donors on a website as well as giving them Discord roles that have no additional permissions (style-only) is allowed.</li>
+        <li>Offering players gameplay advantages or preferential treatment in exchange for money or monetary equivalents (gift cards, digital currencies etc.) is prohibited.
+        Accepting donations is allowed, as long as there are no differences in gameplay between donors and non-donors.
+        Listing donors on a website as well as giving them Discord roles that have no additional permissions (style-only) is allowed.
+        Awarding players monetary rewards through competitive events (tournaments etc.) is allowed.</li>
         <li>This applies to all game servers as well as any other official presences of the community (Discord servers, social media accounts etc.).</li>
       </ol>
     </li>


### PR DESCRIPTION
Clarify that while communities are not allowed to grant players gameplay advantages in exchange for money, giving monetary rewards to players through competitive events (e.g. tournaments) is allowed.

Clarify that this refers to money and monetary equivalents (e.g. gift cards).

Used ChatGPT for brainstorming.