### PR TITLE
DDNet 19.8

### DIFF
--- a/www/downloads/index.html
+++ b/www/downloads/index.html
@@ -4,6 +4,80 @@ title: Downloads - DDraceNetwork
 ---
 <div class="block">
 <h2 id="downloads">Downloads</h2>
+<h3 id="19.8"><a href="#19.8">DDNet 19.8</a></h3>
+<div class="dlfiles">
+  2026-03-12<br/><br/>
+  <ul>
+    <li><a href="DDNet-19.8-win64.zip">Windows&nbsp;64bit</a></li>
+    <li><a href="DDNet-19.8-win-arm64.zip">Windows&nbsp;ARM</a></li>
+    <li><a href="DDNet-19.8-win32.zip">Windows&nbsp;32bit</a></li>
+    <li><a href="DDNet-19.8-linux_x86.tar.xz">Linux&nbsp;x86</a></li>
+    <li><a href="DDNet-19.8-linux_x86_64.tar.xz">Linux&nbsp;x86-64</a></li>
+    <li><a href="DDNet-19.8-macos.dmg">macOS (arm64&nbsp;&amp;&nbsp;x86-64)</a></li>
+    <li><a href="DDNet-19.8.apk">Android</a></li>
+    <li><a href="DDNet-19.8.tar.xz">Source</a></li>
+  </ul>
+</div>
+<div class="dlinfo">
+  <strong>Changelog</strong>
+  <ul>
+    <li>[Client] <strong>Predict envelopes</strong> [<strong>AssassinTee</strong>]</li>
+    <li>[Client] <strong>Predict all sounds and particles</strong> [<strong>KebsCS</strong>]</li>
+    <li>[Client] <strong>Show centiseconds in scoreboard and HUD</strong> [<strong>AssassinTee</strong>]</li>
+    <li>[Client] <strong>Sample loop point support (Opus)</strong> [<strong>SollyBunny</strong>]</li>
+    <li>[Client] <strong>Add real HSL values to color scrollbars</strong> [<strong>AssassinTee</strong>]</li>
+    <li>[Client] <strong>Hook line tip</strong> [<strong>fushi-gg</strong>]</li>
+    <li>[Client] Add scoreboard popup with map info [<strong>KebsCS</strong>]</li>
+    <li>[Client] Show friends regardless of filter in server browser [<strong>KebsCS</strong>]</li>
+    <li>[Client] Render current number of players in community filter, sort by player count [<strong>Robyt3</strong>]</li>
+    <li>[Client] Update unpredicted shadow, add alpha and customization [<strong>fokkonaut</strong>]</li>
+    <li>[Client] Demo menu mouse seek improvements [<strong>dobrykafe</strong>]</li>
+    <li>[Client] Replace line breaks with spaces when pasting multiple lines in chat [<strong>Robyt3</strong>]</li>
+    <li>[Client] Improve user experience when joining Tutorial server [<strong>Robyt3</strong>]</li>
+    <li>[Client] Use racefinish message to stop demo/ghost recording [<strong>Pioooooo</strong>]</li>
+    <li>[Client] Update map best time if a player joins with a better time [<strong>KebsCS</strong>]</li>
+    <li>[Client] Make descriptions of refresh rate settings more clear [<strong>Desour</strong>]</li>
+    <li>[Client] Fix unlimited zoom crashing when zooming out really far [<strong>AssassinTee</strong>]</li>
+    <li>[Client] Fix changing spectator in demo player when paused [<strong>SollyBunny</strong>]</li>
+    <li>[Client] Fix dead players being duplicated [<strong>ChillerDragon</strong>]</li>
+    <li>[Client] Fix prediction with collision tunes [<strong>KebsCS</strong>]</li>
+    <li>[Client] Fix prediction when player has no current weapon [<strong>qxdFox</strong>]</li>
+    <li>[Client] Stop forcing predicted events onto older DDrace servers [<strong>AssassinTee</strong>]</li>
+    <li>[Client] Prevent game from being unpaused during gameover [<strong>Robyt3</strong>]</li>
+    <li>[Client] Fix scrollbar behavior when combining multiple flags [<strong>dobrykafe</strong>]</li>
+    <li>[Client] Add easter mapres from teeworlds [<strong>Pointer31</strong>]</li>
+    <li>[Editor] Fix editor map not being saved if editor is quit before job is done [<strong>Robyt3</strong>]</li>
+    <li>[Editor] Fix editor can't find tele out [<strong>ProfSapphire</strong>]</li>
+    <li>[Editor] Add quick action to show help, fix holding down F1 key [<strong>Robyt3</strong>]</li>
+    <li>[Editor] Fix "Collapse all" button collapsing empty groups [<strong>Robyt3</strong>]</li>
+    <li>[Editor] Add error message when launching local server [<strong>Robyt3</strong>]</li>
+    <li>[Editor] Fix redo of envelope edit actions [<strong>MilkeeyCat</strong>]</li>
+    <li>[Editor] Fix BrushDraw for tile layers [<strong>MilkeeyCat</strong>]</li>
+    <li>[Server] Add rcon/practice command setswitch [<strong>Pioooooo</strong>]</li>
+    <li>[Server] Make cmdlist list only commands without practice flag [<strong>KebsCS</strong>]</li>
+    <li>[Infra.] <strong>Split system.cpp/h into smaller modules</strong> [<strong>Robyt3, heinrich5991</strong>]</li>
+    <li>[Infra.] Improve Emscripten support and error handling [<strong>Robyt3</strong>]</li>
+  </ul>
+  and a lot of smaller fixes, see the <a href="https://github.com/ddnet/ddnet/compare/19.7...19.8">full list of git changes</a>
+</div>
+<br/>
+<h3>Other Downloads</h3>
+<ul>
+  <li><a href="https://store.steampowered.com/app/412220/DDraceNetwork/">Steam package</a></li>
+  <li><a href="https://flathub.org/apps/tw.ddnet.ddnet">Flatpak package</a></li>
+  <li><a href="https://packages.debian.org/search?keywords=ddnet">Debian packages</a></li>
+  <li><a href="https://packages.ubuntu.com/search?keywords=ddnet&searchon=names&section=all">Ubuntu packages</a></li>
+  <li><a href="https://aur.archlinux.org/packages/?O=0&SeB=nd&K=ddnet&outdated=&SB=n&SO=a&PP=50&do_Search=Go">ArchLinux AUR packages</a>, <a href="https://wiki.archlinux.org/index.php/DDRaceNetwork">ArchWiki</a></li>
+  <li id="nightly-builds">Nightly Builds: <a href="DDNet-nightly-win64.zip">Windows&nbsp;64bit</a>, <a href="DDNet-nightly-win-arm64.zip">Windows&nbsp;ARM</a>, <a href="DDNet-nightly-win32.zip">Windows&nbsp;32bit</a>, <a href="DDNet-nightly-linux_x86.tar.xz">Linux&nbsp;x86</a>, <a href="DDNet-nightly-linux_x86_64.tar.xz">Linux&nbsp;x86-64</a>, <a href="DDNet-nightly-macos.dmg">macOS</a>, <a href="DDNet-nightly.apk">Android</a> (<a href="DDNet-nightly.log">build log</a>)</li>
+  <li>Hashes for download verification: <a href="sha256sums.txt">SHA256</a></li>
+  <li>Git repositories: <a href="https://github.com/ddnet/ddnet">DDNet Client &amp; Server</a>, <a href="https://github.com/ddnet/ddnet-maps">Maps</a> (including configs, <a href="https://github.com/ddnet/ddnet-maps/archive/master.zip">download all maps</a>), <a href="https://github.com/ddnet/ddnet-scripts">Scripts</a>, <a href="https://github.com/ddnet/ddnet-libs">Libs</a></li>
+  <li>Raw list of all DDNet ranks, team ranks and maps: <a href="/stats/ddnet-stats.zip">CSV</a>, <a href="/stats/ddnet-sql.zip">SQL</a></li>
+  <li>Map download server: <a href="https://maps.ddnet.org/">List of all maps</a>, <a href="https://maps.ddnet.org/compilations/">Map compilations</a></li>
+  <li><a href="http://www.foveon.de/sonstiges/opusdrop/index.htm">OpusDrop</a> (Convert sound files to Opus for DDNet maps)</li>
+</ul>
+</div>
+<div class="block">
+<h2 id="old-downloads">Old Versions</h2>
 <h3 id="19.7"><a href="#19.7">DDNet 19.7</a></h3>
 <div class="dlfiles">
   2026-01-22<br/><br/>
@@ -56,23 +130,6 @@ title: Downloads - DDraceNetwork
   and a lot of smaller fixes, see the <a href="https://github.com/ddnet/ddnet/compare/19.6...19.7">full list of git changes</a>
 </div>
 <br/>
-<h3>Other Downloads</h3>
-<ul>
-  <li><a href="https://store.steampowered.com/app/412220/DDraceNetwork/">Steam package</a></li>
-  <li><a href="https://flathub.org/apps/tw.ddnet.ddnet">Flatpak package</a></li>
-  <li><a href="https://packages.debian.org/search?keywords=ddnet">Debian packages</a></li>
-  <li><a href="https://packages.ubuntu.com/search?keywords=ddnet&searchon=names&section=all">Ubuntu packages</a></li>
-  <li><a href="https://aur.archlinux.org/packages/?O=0&SeB=nd&K=ddnet&outdated=&SB=n&SO=a&PP=50&do_Search=Go">ArchLinux AUR packages</a>, <a href="https://wiki.archlinux.org/index.php/DDRaceNetwork">ArchWiki</a></li>
-  <li id="nightly-builds">Nightly Builds: <a href="DDNet-nightly-win64.zip">Windows&nbsp;64bit</a>, <a href="DDNet-nightly-win-arm64.zip">Windows&nbsp;ARM</a>, <a href="DDNet-nightly-win32.zip">Windows&nbsp;32bit</a>, <a href="DDNet-nightly-linux_x86.tar.xz">Linux&nbsp;x86</a>, <a href="DDNet-nightly-linux_x86_64.tar.xz">Linux&nbsp;x86-64</a>, <a href="DDNet-nightly-macos.dmg">macOS</a>, <a href="DDNet-nightly.apk">Android</a> (<a href="DDNet-nightly.log">build log</a>)</li>
-  <li>Hashes for download verification: <a href="sha256sums.txt">SHA256</a></li>
-  <li>Git repositories: <a href="https://github.com/ddnet/ddnet">DDNet Client &amp; Server</a>, <a href="https://github.com/ddnet/ddnet-maps">Maps</a> (including configs, <a href="https://github.com/ddnet/ddnet-maps/archive/master.zip">download all maps</a>), <a href="https://github.com/ddnet/ddnet-scripts">Scripts</a>, <a href="https://github.com/ddnet/ddnet-libs">Libs</a></li>
-  <li>Raw list of all DDNet ranks, team ranks and maps: <a href="/stats/ddnet-stats.zip">CSV</a>, <a href="/stats/ddnet-sql.zip">SQL</a></li>
-  <li>Map download server: <a href="https://maps.ddnet.org/">List of all maps</a>, <a href="https://maps.ddnet.org/compilations/">Map compilations</a></li>
-  <li><a href="http://www.foveon.de/sonstiges/opusdrop/index.htm">OpusDrop</a> (Convert sound files to Opus for DDNet maps)</li>
-</ul>
-</div>
-<div class="block">
-<h2 id="old-downloads">Old Versions</h2>
 <h3 id="19.6"><a href="#19.6">DDNet 19.6</a></h3>
 <div class="dlfiles">
   2025-12-14<br/><br/>

--- a/www/index.php
+++ b/www/index.php
@@ -75,7 +75,7 @@ function getOS() {
 }
 
 $user_os = getOS();
-$version = '19.7';
+$version = '19.8';
 
 if ($user_os == 'win32') {
   print '<p class="download"><span class="big"><a href="/downloads/DDNet-' . $version . '-win32.zip">Download DDraceNetwork Client &amp; Server ' . $version . ' for Windows (32bit)</a></span><br/><a href="/downloads/">Other systems and versions, changelogs</a></p>';


### PR DESCRIPTION
Depends on https://github.com/ddnet/ddnet/pull/11877

The changelog is LLM-generated for the first time, mostly because I already spent ~1 day getting the libs updated.