### PR TITLE
Restructure nightly build and other downloads

### DIFF
--- a/www/downloads/index.html
+++ b/www/downloads/index.html
@@ -61,14 +61,30 @@ title: Downloads - DDraceNetwork
   and a lot of smaller fixes, see the <a href="https://github.com/ddnet/ddnet/compare/19.7...19.8">full list of git changes</a>
 </div>
 <br/>
-<h3>Other Downloads</h3>
+<hr/>
+<h3 id="nightly-builds"><a href="#nightly-builds">Nightly Builds</a></h3>
+<p>Nightly builds are updated every night based on the latest changes in the <a href="https://github.com/ddnet/ddnet">GitHub repository</a>.
+Nightly builds are intended for testing and early access to features and bug fixes, but they might contain new bugs as well.
+If you encounter bugs, please report them by opening an issue on <a href="https://github.com/ddnet/ddnet/issues">GitHub</a> or in the #bugs channel on our <a href="https://ddnet.org/discord">Discord server</a>.</p>
+<ul>
+  <li><a href="DDNet-nightly-win64.zip">Windows&nbsp;64bit</a></li>
+  <li><a href="DDNet-nightly-win-arm64.zip">Windows&nbsp;ARM</a></li>
+  <li><a href="DDNet-nightly-win32.zip">Windows&nbsp;32bit</a></li>
+  <li><a href="DDNet-nightly-linux_x86.tar.xz">Linux&nbsp;x86</a></li>
+  <li><a href="DDNet-nightly-linux_x86_64.tar.xz">Linux&nbsp;x86-64</a></li>
+  <li><a href="DDNet-nightly-macos.dmg">macOS</a></li>
+  <li><a href="DDNet-nightly.apk">Android</a></li>
+  <li><a href="DDNet-nightly.tar.xz">Source</a></li>
+  <li><a href="DDNet-nightly.log">Build log</a></li>
+</ul>
+<hr/>
+<h3 id="other-downloads"><a href="#other-downloads">Other Downloads</a></h3>
 <ul>
   <li><a href="https://store.steampowered.com/app/412220/DDraceNetwork/">Steam package</a></li>
   <li><a href="https://flathub.org/apps/tw.ddnet.ddnet">Flatpak package</a></li>
   <li><a href="https://packages.debian.org/search?keywords=ddnet">Debian packages</a></li>
   <li><a href="https://packages.ubuntu.com/search?keywords=ddnet&searchon=names&section=all">Ubuntu packages</a></li>
   <li><a href="https://aur.archlinux.org/packages/?O=0&SeB=nd&K=ddnet&outdated=&SB=n&SO=a&PP=50&do_Search=Go">ArchLinux AUR packages</a>, <a href="https://wiki.archlinux.org/index.php/DDRaceNetwork">ArchWiki</a></li>
-  <li id="nightly-builds">Nightly Builds: <a href="DDNet-nightly-win64.zip">Windows&nbsp;64bit</a>, <a href="DDNet-nightly-win-arm64.zip">Windows&nbsp;ARM</a>, <a href="DDNet-nightly-win32.zip">Windows&nbsp;32bit</a>, <a href="DDNet-nightly-linux_x86.tar.xz">Linux&nbsp;x86</a>, <a href="DDNet-nightly-linux_x86_64.tar.xz">Linux&nbsp;x86-64</a>, <a href="DDNet-nightly-macos.dmg">macOS</a>, <a href="DDNet-nightly.apk">Android</a> (<a href="DDNet-nightly.log">build log</a>)</li>
   <li>Hashes for download verification: <a href="sha256sums.txt">SHA256</a></li>
   <li>Git repositories: <a href="https://github.com/ddnet/ddnet">DDNet Client &amp; Server</a>, <a href="https://github.com/ddnet/ddnet-maps">Maps</a> (including configs, <a href="https://github.com/ddnet/ddnet-maps/archive/master.zip">download all maps</a>), <a href="https://github.com/ddnet/ddnet-scripts">Scripts</a>, <a href="https://github.com/ddnet/ddnet-libs">Libs</a></li>
   <li>Raw list of all DDNet ranks, team ranks and maps: <a href="/stats/ddnet-stats.zip">CSV</a>, <a href="/stats/ddnet-sql.zip">SQL</a></li>


### PR DESCRIPTION
Move nightly build to a separate header and add a short explanation for them.

Add nightly source download link for completeness. The file already exists.

Add clickable link anchors for nightly build and other downloads.