### PR TITLE
Add Media page

### DIFF
--- a/add_video.py
+++ b/add_video.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import date as date_type
+from pathlib import Path
+
+data_file = Path(__file__).parent / "www" / "_data" / "videos.yml"
+
+
+def find_id(text):
+    if re.fullmatch(r"[A-Za-z0-9_-]{11}", text):
+        return text
+    match = re.search(r"(?:v=|youtu\.be/|embed/|shorts/)([A-Za-z0-9_-]{11})", text)
+    if match:
+        return match.group(1)
+    return None
+
+
+def load_metadata(video_id):
+    url = "https://www.youtube.com/oembed?" + urllib.parse.urlencode(
+        {"url": f"https://www.youtube.com/watch?v={video_id}", "format": "json"}
+    )
+    request = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(request, timeout=15) as response:
+        return json.load(response)
+
+
+def quote(text):
+    return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Feature a video on the frontpage and add it to /media/."
+    )
+    parser.add_argument("video", help="YouTube video id or url")
+    parser.add_argument(
+        "--date",
+        default=date_type.today().isoformat(),
+        help="date it gets featured, defaults to today",
+    )
+    parser.add_argument("--title", help="override the title from YouTube")
+    parser.add_argument("--author", help="override the channel name from YouTube")
+    args = parser.parse_args()
+
+    video_id = find_id(args.video)
+    if not video_id:
+        sys.exit(f"could not read a video id out of {args.video!r}")
+
+    lines = data_file.read_text(encoding="utf-8").splitlines()
+    if any(line.strip() == f"- id: {video_id}" for line in lines):
+        sys.exit(f"{video_id} is already in {data_file.name}")
+
+    title = args.title
+    author = args.author
+    if title is None or author is None:
+        try:
+            metadata = load_metadata(video_id)
+        except urllib.error.HTTPError as error:
+            if error.code in (401, 403, 404):
+                sys.exit(f"{video_id} is not publicly available on YouTube")
+            raise
+        title = title if title is not None else metadata.get("title", "")
+        author = author if author is not None else metadata.get("author_name", "")
+
+    entry = [
+        f"- id: {video_id}",
+        f"  date: {args.date}",
+        f"  title: {quote(title)}",
+        f"  author: {quote(author)}",
+    ]
+
+    # newest first, so the entry goes above the first existing one
+    insert_at = next(
+        (n for n, line in enumerate(lines) if line.startswith("- id: ")), len(lines)
+    )
+    lines[insert_at:insert_at] = entry
+    data_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    print(f"added {video_id} to {data_file}")
+    print(f"  {title} by {author}, featured {args.date}")
+
+
+if __name__ == "__main__":
+    main()

--- a/www/_data/menus.yml
+++ b/www/_data/menus.yml
@@ -16,6 +16,7 @@ nav: |
 subnav: |
   <ul>
     <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
+    <li><a href="/videos/">Videos</a></li>
     <li><a href="/server/">Server&nbsp;Features</a></li>
     <li><a href="/client/">Client&nbsp;Features</a></li>
     <li><a href="/map/">Map&nbsp;Features</a></li>

--- a/www/_data/videos.yml
+++ b/www/_data/videos.yml
@@ -1,0 +1,1220 @@
+- id: wGBvuIM7FXQ
+  date: 2026-07-29
+  title: "[DDNet] DEATHBOW - Rank 1 | Hollow. & Tyga."
+  author: "Hollow TW"
+- id: GSFbFsgYSuU
+  date: 2026-05-25
+  title: "The Rotting Halls Trailer"
+  author: "Pipou"
+- id: sDNBQHM1FU0
+  date: 2026-04-05
+  title: "[Dummy] Darkspy Rank 1 by Natsume - Teeworlds DDNet"
+  author: "rare"
+- id: Qv5QVjUNrgw
+  date: 2026-03-21
+  title: "DEATHBOW RANK 1 [DDNet]"
+  author: "Freezestyler Teeworlds"
+- id: kEdntDcFmoo
+  date: 2026-03-04
+  title: "DEATHBOW Trailer - Tournament map by Exotix - DDNet Teeworlds"
+  author: "rare"
+- id: BfD6QBSvguI
+  date: 2026-02-27
+  title: "[DDNet] After 76 Hours – The Hardest Solo Map “Exanimus” Cleared ★★★★★ | fomjn"
+  author: "pet"
+- id: 1ObhqpB2qXc
+  date: 2026-02-07
+  title: "RARES PLAY #1 - Springlobe Sunday (2/3) Teeworlds DDNet"
+  author: "rare"
+- id: ti1TKY1TMh0
+  date: 2026-01-24
+  title: "Paralyzed RANK 1 [DDNet]"
+  author: "Freezestyler Teeworlds"
+- id: buQtI0oJn7U
+  date: 2025-12-30
+  title: "RARES PLAY #1 - Springlobe Sunday (1/3) Teeworlds DDNet"
+  author: "rare"
+- id: I6hdjxDH-aA
+  date: 2025-11-19
+  title: "How to do - Ghoul DDnet"
+  author: "Paralix19"
+- id: HS9grU4DvY0
+  date: 2025-09-21
+  title: "Grandma RANK 1 [DDNet]"
+  author: "Freezestyler Teeworlds"
+- id: PdvROmfXqNo
+  date: 2025-09-11
+  title: "How to do - Naufrage 4 DDnet"
+  author: "Paralix19"
+- id: qAJISs6GYe0
+  date: 2025-07-27
+  title: "DDNet - Pros Play TW 166: Patience"
+  author: "Aoe"
+- id: r7uU2AQS9lc
+  date: 2025-06-14
+  title: "DDNet - Abyss Trailer"
+  author: "Aoe"
+- id: mW5aurN-nH4
+  date: 2025-03-17
+  title: "DDNet - Chasing Perfection"
+  author: "Aoe"
+- id: r7Vpws2Wf94
+  date: 2025-02-24
+  title: "DDNet - Pros Play TW 160: Naufrage 4 Tournament"
+  author: "Aoe"
+- id: VR1sJcW0Y8o
+  date: 2025-02-12
+  title: "One way freeze by Destoros"
+  author: "Destoros"
+- id: bQjZaOLbym8
+  date: 2025-01-17
+  title: "Funny Moments 19 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: RMmDPoaCsqI
+  date: 2025-01-07
+  title: "a few ddnet speedruns | DDNet Speedrun Compilation #1"
+  author: "Broso56"
+- id: ID3fzWoWLPs
+  date: 2024-12-03
+  title: "How to do - Cave of Harmony DDnet"
+  author: "Paralix19"
+- id: 8TZRo6s7s2w
+  date: 2024-08-19
+  title: "DDNet \"Tutorial\" Tutorial"
+  author: "Gumba"
+- id: 9G_hLBOvcBo
+  date: 2024-06-28
+  title: "Teeworlds - How to make a skin? | DDNet / Teeworlds skin tutorial"
+  author: "TortiLeq"
+- id: yzrv9dentCM
+  date: 2024-06-08
+  title: "How to do - Scuba DDnet"
+  author: "Paralix19"
+- id: jW21pPkdLBw
+  date: 2024-05-30
+  title: "DDNet Mobile : Ravillion Insane 2"
+  author: "Forgotten Cat"
+- id: Z5m4rIWbMQg
+  date: 2024-05-12
+  title: "[DDNet] Map: Hostile 3 | Rank 1 by VéNa & Nehr - 05:45.86"
+  author: "Pipou"
+- id: xkmq_SjKed0
+  date: 2023-12-25
+  title: "How to do - Nordrhein-Westfalen DDnet"
+  author: "Paralix19"
+- id: vCvuTPe90IE
+  date: 2023-12-20
+  title: "Stronghold 4 [Final] Trailer"
+  author: "Pipou"
+- id: W9BvRrNaA8Y
+  date: 2023-12-18
+  title: "How to do - Twin Electric Field DDnet"
+  author: "Paralix19"
+- id: QycW8GnYsaM
+  date: 2023-12-14
+  title: "How to do - Headache DDnet"
+  author: "Paralix19"
+- id: ivDABfrIXQQ
+  date: 2023-11-15
+  title: "Lonely Swim | Teeworlds"
+  author: "ano__"
+- id: YHRX0fulGZ8
+  date: 2023-10-14
+  title: "Teeworlds | Non-standard way to finish dummy maps #1 (teamranks)"
+  author: "n9 teeworlds"
+- id: LYUBYN5R0N4
+  date: 2023-09-05
+  title: "DDNet FUJI - [Rank 1 + First 2p finish] by Cans & rqza !!"
+  author: "David Villa - Teeworlds"
+- id: 0M2V2wDqnTM
+  date: 2023-07-22
+  title: "[DDNet] Uncrowned King of speed - uq"
+  author: "David Villa - Teeworlds"
+- id: typCY28F214
+  date: 2023-07-14
+  title: "Stronghold BUT Only the Blocks the World Record Touches..."
+  author: "Gazebr"
+- id: LCEiIub1jeM
+  date: 2023-06-13
+  title: "[DDNet] Map: Goo! | Rank 1 by VéNa & coradax - 02:44.04"
+  author: "Pipou"
+- id: Apdb4IQVArQ
+  date: 2023-05-27
+  title: "This Rank 1 Came Out of Nowhere... (DDNet)"
+  author: "Gazebr"
+- id: bqf4yH4mpVU
+  date: 2023-05-08
+  title: "[DDNet] Heartcore II | Brokecdx- & paradise | Rank1"
+  author: "Brokecdx-"
+- id: jUJ2q0i2Q1w
+  date: 2023-05-01
+  title: "rank 1's found on an old tape | Teeworlds"
+  author: "ano__"
+- id: v26jtWoT5j4
+  date: 2023-04-20
+  title: "[DDNet] Map: Legacy | Rank 1 by Cireme - 05:19.12"
+  author: "Pipou"
+- id: ESZbuNHYNXY
+  date: 2023-04-11
+  title: "Teeworlds | The solo skips Travel"
+  author: "n9 teeworlds"
+- id: RVT5zKw0x1s
+  date: 2023-04-02
+  title: "[DDNet] Aimateur | Brokecdx- & paradise | Rank1"
+  author: "Brokecdx-"
+- id: VNYxVrcrPKM
+  date: 2023-03-26
+  title: "Road to 1.000 | Thank you"
+  author: "David Villa - Teeworlds"
+- id: zqTmZ9YB534
+  date: 2023-02-13
+  title: "DDNet - Weapon Finals II"
+  author: "Aoe"
+- id: PjIT6J9Yhs4
+  date: 2023-02-06
+  title: "DDNet Multeasymap backwards | No help, with explanation | Cthulhu & Bota"
+  author: "Bota"
+- id: yZzwTO4mQWU
+  date: 2023-01-26
+  title: "How to do - Gehenna DDnet"
+  author: "Paralix19"
+- id: sKm9DU3CU-I
+  date: 2023-01-24
+  title: "[DDNet]     R   A   N   K   1"
+  author: "Brokecdx-"
+- id: 54J-F7BHL4o
+  date: 2023-01-20
+  title: "All short race Rank 1 on DDNet | Teeworlds"
+  author: "ano__"
+- id: 5F8kcJgOUVM
+  date: 2023-01-13
+  title: "DDNet - Pros Play TW 145: I Can Smoke Now!"
+  author: "Aoe"
+- id: ddITF6G7EGo
+  date: 2023-01-07
+  title: "[DDNet] Not Really Yo'Ci | Brokecdx- & paradise | Rank1"
+  author: "Brokecdx-"
+- id: sDo4iKHNqJI
+  date: 2022-12-06
+  title: "DDNet - Adorenarine 5★ Insane First 2p Finish!"
+  author: "Aoe"
+- id: dSJFJJWtCvA
+  date: 2022-11-07
+  title: "How to beat a perfect run"
+  author: "David Villa - Teeworlds"
+- id: aTmtWYcC4ug
+  date: 2022-10-26
+  title: "Adorenarine - Map Trailer"
+  author: "David Villa - Teeworlds"
+- id: UIEHOuFOAG8
+  date: 2022-10-20
+  title: "I'm really bad at naming things ^^"
+  author: "cheeser0613"
+- id: BY0B-wR5cX0
+  date: 2022-10-07
+  title: "Annoying Brutal map with dummys [German] | Teeworlds Commentary #2"
+  author: "TeeworldsEasy"
+- id: 05LRSGq8nT4
+  date: 2022-09-25
+  title: "DDNet - Pros Play TW 144: The Drunk Coach"
+  author: "Aoe"
+- id: FkC-VJEBHHk
+  date: 2022-09-16
+  title: "Teeworlds*°120 - run_Jellyfish_Fields"
+  author: "David Villa - Teeworlds"
+- id: dfmNCWu__IM
+  date: 2022-09-11
+  title: "[Teeworlds] | Not Naufrage 4 Rank 1 in 14:44 | Insane 1★"
+  author: "Spooky"
+- id: m2Ow2s8Szcs
+  date: 2022-09-04
+  title: "[Teeworlds] | Tsunami(40,84) Rank 1 ft. | Brokecdx-"
+  author: "Spooky"
+- id: -QlS_KRqLSs
+  date: 2022-09-01
+  title: "DDNet Tournament Teaser - Strategic Paraplegic"
+  author: "louis"
+- id: fY6btJ4tImU
+  date: 2022-08-21
+  title: "DDNet - Proof Chrona Is Cheating"
+  author: "Aoe"
+- id: eWHcvEX-bZ0
+  date: 2022-08-12
+  title: "Funny Moments 18 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: jszRJqZwUmM
+  date: 2022-07-09
+  title: "[Teeworlds] | Short speedruns Rank 1 | ft. Brokecdx-, rezee and Cireme"
+  author: "Spooky"
+- id: 4hpPLkn1IYE
+  date: 2022-06-28
+  title: "DDNet(Teeworlds) in a nutshell"
+  author: "cheeser0613"
+- id: Umrlmx6bpKI
+  date: 2022-06-22
+  title: "DDNet troll moment #01"
+  author: "cheeser0613"
+- id: XlJOloJjUeM
+  date: 2022-06-18
+  title: "[DDNet/Teeworlds] Just Shitfly Rank1 By PlantKnight & iParano"
+  author: "Plant"
+- id: B1dtn6z5DP8
+  date: 2022-06-13
+  title: "[DDNet/Teeworlds] Handifly Rank1 By iParano & PlantKnight"
+  author: "Plant"
+- id: rBHXn1VLNk0
+  date: 2022-06-03
+  title: "[DDNet/Teeworlds] Just Rocketfly Rank1"
+  author: "Plant"
+- id: 80qhW_ICRBc
+  date: 2022-06-02
+  title: "I replaced my ddnet sound files..."
+  author: "Kujire"
+- id: ib-rtPGtqrU
+  date: 2022-05-26
+  title: "Rotate, but only the hard parts | DDNet"
+  author: "louis"
+- id: NSQU2iTzQII
+  date: 2022-05-01
+  title: "How to do - Aimbot DDnet"
+  author: "Paralix19"
+- id: xVs-2xBcajg
+  date: 2022-04-20
+  title: "Teeworlds - Milthrid Core Rank 1 in 07:35 by Pepegepeg [Epic Shortcut]"
+  author: "KlexMikrowelle"
+- id: tY4vGm-H6gA
+  date: 2022-04-12
+  title: "How to do - Aimlicious DDnet"
+  author: "Paralix19"
+- id: rSH95NtM6h4
+  date: 2022-04-08
+  title: "How to do - Smash DDnet"
+  author: "Paralix19"
+- id: mmfJStj0wXs
+  date: 2022-04-06
+  title: "DDNet on r/place | Timelapse & Discord Highlights"
+  author: "GravityContained"
+- id: lm1h1oqpoFg
+  date: 2022-03-31
+  title: "Multeasymap Cheat (APRIL FOOLS JOKE)"
+  author: "David Villa - Teeworlds"
+- id: 4V1QEu97Ils
+  date: 2022-03-21
+  title: "DDNet - Weapon Finals Playthrough By Chrona"
+  author: "Aoe"
+- id: 69IYRk1tQ2k
+  date: 2022-03-14
+  title: "Funny Moments 17 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: omqSBZEn6JQ
+  date: 2022-03-03
+  title: "DDNet - Pros Play TW 138: Sweatdren"
+  author: "Aoe"
+- id: Ql-NNOhXhn8
+  date: 2022-02-19
+  title: "Jotaro Plays DDNet"
+  author: "T tee"
+- id: gjymcTOQWfA
+  date: 2022-02-04
+  title: "DDNet - Stronghold 2 Rank 1 by PlantKnight & Dummy"
+  author: "Aoe"
+- id: Edwha-JFv-g
+  date: 2021-12-20
+  title: "[Teeworlds] | Just Fly 3 Rank 1 by Spooky and iParano"
+  author: "Spooky"
+- id: ELE9iad_Pqo
+  date: 2021-11-28
+  title: "[DDNet/Teeworlds] Just Triple Fly Rank1 PlantKnight & iParano"
+  author: "Plant"
+- id: 1G3yj5s9Wlw
+  date: 2021-10-19
+  title: "[Teeworlds] | Short 1,2 Rank1 by Spooky and coradax"
+  author: "Spooky"
+- id: VWPPnJBzrN4
+  date: 2021-10-01
+  title: "Teeworlds*°62 - Kobra New Rank 1 (beaten)"
+  author: "David Villa - Teeworlds"
+- id: 7-hkzrg3sT8
+  date: 2021-09-14
+  title: "Funny Moments 16 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: dujUeC8tE8I
+  date: 2021-07-15
+  title: "[DDNet/Teeworlds Montage] Certified Plant moments"
+  author: "Plant"
+- id: cOQNpwLwutc
+  date: 2021-07-01
+  title: "Clan Gatos✈ Funny moments [DDNet] Teeworlds Montage [CHL]"
+  author: "Chyste"
+- id: yt6jIteU4Sw
+  date: 2021-06-26
+  title: "DDNet - Pros Play TW 128: Fat Asses!"
+  author: "Aoe"
+- id: b-YWpPxQvps
+  date: 2021-06-02
+  title: "[Teeworlds] Multeasymap(4:58) | Brokecdx- & rockuS | Rank1"
+  author: "Brokecdx-"
+- id: DGHXMhtpJy8
+  date: 2021-05-18
+  title: "DDNet Quick Tournament #57 - Bollermann by Cøke"
+  author: "Stepfunn"
+- id: -Lb4ydxCc_Y
+  date: 2021-05-13
+  title: "[Insane] Resistance | rockuS & Brokecdx- | Rank1"
+  author: "Brokecdx-"
+- id: vjI3oGNkxGw
+  date: 2021-05-06
+  title: "DDNet - Pros Play TW 126: First Finish!"
+  author: "Aoe"
+- id: _4kr9fdajxY
+  date: 2021-04-27
+  title: "[Teeworlds]    S I M P L E P L A Y S    |  Brokecdx- & rockuS | Rank1"
+  author: "Brokecdx-"
+- id: RirMlbgd5gY
+  date: 2021-04-18
+  title: "Top 25 Best DDNet Players Ranking (Update by 2021-04-17)"
+  author: "Eki_Channel"
+- id: PjXDbsG42Kw
+  date: 2021-04-12
+  title: "Kobra 2 - 8:39.98 [bubliman & Yumiko] Old Rank1"
+  author: "bubliman"
+- id: 63X0Jg5tgY8
+  date: 2021-04-05
+  title: "DDNet - Pros Play TW 125: Laags!"
+  author: "Aoe"
+- id: i7J7GBX8meo
+  date: 2021-04-05
+  title: "DDNET QUICK TOURNAMENT #55 - MOVENTER BY THEMIX"
+  author: "Stepfunn"
+- id: b9trI-CXviw
+  date: 2021-04-04
+  title: "(Ger) Teeworlds 2nd DDNet Tournament 2021 - Moventer (#55) mit Lunamy & Twike"
+  author: "KlexMikrowelle"
+- id: gp4wXgS3uO4
+  date: 2021-03-01
+  title: "Every Technique You Need To Know (Novice) - DDRaceNetwork"
+  author: "DDJoyNetwork"
+- id: w-xHI7_ZYGc
+  date: 2021-02-07
+  title: "Teeworlds | DDRace - milk Speedrun by Destin & ✧Rune [Rank 1]"
+  author: "TeeworldsEasy"
+- id: kNGmN3QI4Ic
+  date: 2021-01-30
+  title: "DDNet - 3,000 Sub montage !"
+  author: "Aoe"
+- id: KM4bP_hiWfQ
+  date: 2021-01-24
+  title: "Teeworlds DDNet Quick Tournament #54 - Knux by Knuski"
+  author: "KlexMikrowelle"
+- id: 8_Hxrci7spA
+  date: 2021-01-21
+  title: "DDNet - Pros Play TW 121: Ego Noobs"
+  author: "Aoe"
+- id: sg3eiAAWDmk
+  date: 2021-01-14
+  title: "DDNet - Pros Play TW 120: Heart Attack"
+  author: "Aoe"
+- id: -sN8ZkUBOPA
+  date: 2020-12-20
+  title: "Funny Moments 14 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: o3UvvCWRal4
+  date: 2020-11-24
+  title: "DDNet - Aimateur Sneakpeak"
+  author: "Aoe"
+- id: MV58dmt8QGo
+  date: 2020-11-04
+  title: "Lavender Forest Trailer"
+  author: "Pipou"
+- id: VxGdM2Hz_Gs
+  date: 2020-10-20
+  title: "DDNet - Pros Play TW 112: Cor Biggest Legend!"
+  author: "Aoe"
+- id: C1OW-DzcIxw
+  date: 2020-10-08
+  title: "DDNet - Pros Play TW 107: Hi Youtube"
+  author: "Aoe"
+- id: xtB7LmNl7BI
+  date: 2020-09-15
+  title: "The Adventure Begins | #1 | DDraceNetwork Gameplay Series / Tutorial"
+  author: "louis"
+- id: Vu-nvldx8Sk
+  date: 2020-08-18
+  title: "DDraceNetwork Tutorial - Basic Guide for New Players"
+  author: "louis"
+- id: c8QGu6J8Imw
+  date: 2020-08-17
+  title: "Rapid by Pulsar (Solo ★★★✰✰) | DDNet 7th Birthday Tournament"
+  author: "Ryozuki"
+- id: vou0Mp-OAt4
+  date: 2020-08-09
+  title: "Teeworlds Tournament  DDNet 7th Birthday on  The Dungeon"
+  author: "maggi323"
+- id: ZLZ2T5flR0I
+  date: 2020-08-08
+  title: "Teeworlds Brutal Tournament  - Lotus"
+  author: "maggi323"
+- id: siTXd81HCeY
+  date: 2020-08-08
+  title: "Lotus | Teeworlds DDNet 7th Birthday Tournament"
+  author: "Ryozuki"
+- id: gM7oIx3MQHE
+  date: 2020-07-11
+  title: "Patchwork | Teeworlds DDNet 7th Birthday Tournament"
+  author: "Ryozuki"
+- id: txsHmWDzM60
+  date: 2020-07-09
+  title: "Mina Rank 1"
+  author: "Kenzo"
+- id: xhMJoNo0N_o
+  date: 2020-06-17
+  title: "Spæd TeeworldsMontage #2"
+  author: "Spaed Clan"
+- id: UUgM6JdyMpM
+  date: 2020-05-03
+  title: "2 To Tango | Teeworlds DDNet Quick Tournament #50"
+  author: "Ryozuki"
+- id: i0QYxqFRFIw
+  date: 2020-05-03
+  title: "Teeworlds - mmips Rank 1 in 03:48 with mini skip by Genex & Novic"
+  author: "KlexMikrowelle"
+- id: nvjZ7d7PFRM
+  date: 2020-03-29
+  title: "Teeworlds - Aurora Rank 1 by Tyga."
+  author: "FirstClass Records"
+- id: PlADvR9Ny4o
+  date: 2020-02-16
+  title: "Teeworlds DDNet - Shooting Range Tournament"
+  author: "Ryozuki"
+- id: HECjeng6WUc
+  date: 2020-02-02
+  title: "Teeworlds | DDRace Aurora - Playthrough"
+  author: "TeeworldsEasy"
+- id: -_nzgtl-GzE
+  date: 2020-01-26
+  title: "DDNet - Quick Tournament #49"
+  author: "Ryozuki"
+- id: m9wyX0njHEs
+  date: 2020-01-20
+  title: "Как играть в DDNet? — основы DDRace"
+  author: "Arseniy Zarche"
+- id: foWISJIoCSo
+  date: 2020-01-03
+  title: "Top 25 Best DDNet Players Ranking (2013-2019) (add total points)"
+  author: "Eki_Channel"
+- id: W97eWhVEjTA
+  date: 2020-01-01
+  title: "Top 25 Best DDNet Players Ranking (2013-2019)"
+  author: "Eki_Channel"
+- id: P0Emv1tqNm8
+  date: 2019-11-05
+  title: "DDNet - Pros Play TW 102: Aimazing!"
+  author: "Aoe"
+- id: pLDauBIDFHU
+  date: 2019-09-18
+  title: "Airsky in 3:16 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: T-mEKVrU308
+  date: 2019-07-26
+  title: "Teeworlds montage [Vrac] 3"
+  author: "‡ DarkOort ‡"
+- id: DZpJ4orta_o
+  date: 2019-07-08
+  title: "Teeworlds meme montage by ZiKkie"
+  author: "TwiceRus"
+- id: ZK--AOBZhbs
+  date: 2019-07-07
+  title: "Teeworlds DDNet Tournament - Stronghold 3"
+  author: "KlexMikrowelle"
+- id: CYYVvA4XHRY
+  date: 2019-07-06
+  title: "Teeworlds - Baby Aim 1.0 Rank 1 in 07:11 min by Pet & xeno"
+  author: "KlexMikrowelle"
+- id: 7Q6hbDbUTrk
+  date: 2019-06-10
+  title: "Springlobe 3 - Teaser"
+  author: "TeeWorlds Runs"
+- id: sDoOp19O5_Q
+  date: 2019-06-04
+  title: "Teeworlds [DDNet] Random moments [11] GER"
+  author: "mrs. Teeworlds"
+- id: Lgw2e9XLp_Y
+  date: 2019-05-26
+  title: "Winner Race | DDNet Tournament 47 (N9mkOik)"
+  author: "Ryozuki"
+- id: _vElENzhMt0
+  date: 2019-05-26
+  title: "TEEWORLDS SOLO TOURNAMENT #47"
+  author: "maggi323"
+- id: nEE7Xa_A6yg
+  date: 2019-05-19
+  title: "Teeworlds [DDNet] Random moments [10] GER"
+  author: "mrs. Teeworlds"
+- id: TIiLfmSa8JQ
+  date: 2019-05-12
+  title: "Funny Moments 12 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: qhaxOaGjVyY
+  date: 2019-04-26
+  title: "Just Fly 1 in 01:03 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: fTgy7aEO5w8
+  date: 2019-04-14
+  title: "Teeworlds [DDNet] Random moments [9] GER"
+  author: "mrs. Teeworlds"
+- id: JsO6QcWCuog
+  date: 2019-04-08
+  title: "DDNet - Pros Play TW 100: Gay Worlds"
+  author: "Aoe"
+- id: AEpwlUVv-d4
+  date: 2019-03-27
+  title: "Teeworlds - Lockdown Rank 1 in 22:21 min by Shawn. & kys :)"
+  author: "KlexMikrowelle"
+- id: h2seMT8D4x0
+  date: 2019-03-19
+  title: "Teeworlds | Anim Rank1 | Dummy ★★★★"
+  author: "Spaed Clan"
+- id: 4D0fA1EHrI8
+  date: 2019-03-09
+  title: "Grim Reaper 5★Insane | Vendetta & N9mkOik | First Finish: 20:13.94"
+  author: "corneum"
+- id: PxWAz_XqmcM
+  date: 2019-03-04
+  title: "DDNet - Pros Play TW 99: OOOOOAARRR!!"
+  author: "Aoe"
+- id: 34KRpO70ywo
+  date: 2019-02-25
+  title: "[Teeworlds] Montage 6 - Impossible"
+  author: "teeworlds_Twist"
+- id: TdcFqorHMjw
+  date: 2019-02-16
+  title: "Yo'Ci rank1 in 7:09min by Vendetta & N9mkoik (Insane★(Vendettas view))"
+  author: "corneum"
+- id: Fqa3ny1jLWs
+  date: 2019-01-31
+  title: "Resistance (with UroboroS hammers) [Teeworlds]"
+  author: "Rockus Teeworlds"
+- id: BjaRY024Cyc
+  date: 2018-12-25
+  title: "Funny Moments 11 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: WUC47Ip9iGo
+  date: 2018-12-21
+  title: "10 фактов о DDNet клиенте, которых вы, возможно, не знали!"
+  author: "Arseniy Zarche"
+- id: _A4RAJBoJ6U
+  date: 2018-11-30
+  title: "WENASQUAD - Falling Down [INSANE MAP]"
+  author: "Kenzo"
+- id: dhPHTQu7oFY
+  date: 2018-11-04
+  title: "[Teeworlds] Montage 4"
+  author: "teeworlds_Twist"
+- id: Cn87rSsnaEQ
+  date: 2018-10-28
+  title: "DDNet vs Bots"
+  author: "Ryozuki"
+- id: 43A0CShojUM
+  date: 2018-10-07
+  title: "Teeworlds Epinephrine Playthrough/Trailer"
+  author: "SilexTw"
+- id: bcys_l20cKE
+  date: 2018-09-24
+  title: "Funny Moments 10 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: G2itBn9UCRg
+  date: 2018-09-18
+  title: "Speedfly Rank 1 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: hNXhXb-oCs0
+  date: 2018-08-01
+  title: "TeeWorlds. Trailer: LichKing"
+  author: "Arem Shin"
+- id: Ere9zNghKgQ
+  date: 2018-07-15
+  title: "🥇BlackBear 1-7 rank1 by N9mkOik"
+  author: "corneum"
+- id: SdiXbcdTT6w
+  date: 2018-06-20
+  title: "Flux [Teeworlds]"
+  author: "Rockus Teeworlds"
+- id: A3CuW5n6ClM
+  date: 2018-06-06
+  title: "[Teeworlds] 100 Subscriber SPECIAL"
+  author: "teeworlds_Twist"
+- id: x2TlNNC9Dt4
+  date: 2018-05-10
+  title: "[Teeworlds] First Try [Rank 1 with cut]"
+  author: "teeworlds_Twist"
+- id: Qv2yF_yangY
+  date: 2018-04-01
+  title: "DDNet Insane - 4u - Top Rank"
+  author: "deen"
+- id: eZ_AM2mcPE8
+  date: 2018-03-27
+  title: "Adrenaline 5 - DataClaw and xeno [Rank1] [Teeworlds/DDrace]"
+  author: "Prudrugtiq"
+- id: HQnMp4INtA8
+  date: 2018-02-25
+  title: "N9mkOik ddnet solo runs 2 [Teeworlds]"
+  author: "Prudrugtiq"
+- id: 6aYRStYQOxs
+  date: 2018-02-17
+  title: "[Teeworlds] DDRace - Baby Aim 2 Rank 1 by iParano & Nekoma"
+  author: "Ryozuki"
+- id: bcTEY7Thajs
+  date: 2018-02-14
+  title: "[Teeworlds] At Night 2 [Rank 1]"
+  author: "teeworlds_Twist"
+- id: ljmHVSRndyU
+  date: 2018-02-07
+  title: "[Teeworlds] Mystical Island [Rank 1]"
+  author: "teeworlds_Twist"
+- id: xBdp5nKuF3E
+  date: 2018-01-24
+  title: "N9mkOik ddnet solo runs [Teeworlds]"
+  author: "Prudrugtiq"
+- id: tuQHjuMk6eE
+  date: 2018-01-21
+  title: "Ghoul insane ★★★✰✰ - Kicker & Vendetta - TOP 1 ( Teeworlds , DDNet )"
+  author: "TeeWorlds Runs"
+- id: vf7PCaQFFmE
+  date: 2018-01-06
+  title: "Resistance Insane ★★ - Kicker & Vendetta - TOP 1 ( TeeWorlds , DDNet )"
+  author: "TeeWorlds Runs"
+- id: ioSLJNrpd6g
+  date: 2017-12-31
+  title: "[Teeworlds] Just Ragequit [Rank 1]"
+  author: "teeworlds_Twist"
+- id: fT7IYXuH_dE
+  date: 2017-12-24
+  title: "Random Moments 8 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: RWssJYpWgkQ
+  date: 2017-12-21
+  title: "[Teeworlds] DarkCore 3 [Rank 1]"
+  author: "teeworlds_Twist"
+- id: frcnKUzPHKs
+  date: 2017-11-28
+  title: "[Teeworlds] Out of Castle [Rank 1]"
+  author: "teeworlds_Twist"
+- id: VLt1TsmGU84
+  date: 2017-11-26
+  title: "Stronghold II Trailer"
+  author: "Pipou"
+- id: Do_EM9VQNqk
+  date: 2017-10-13
+  title: "Russian boys by ZiKkie"
+  author: "TwiceRus"
+- id: t16zTO96vgI
+  date: 2017-09-17
+  title: "Game City (Teeworlds)"
+  author: "fikmesån"
+- id: RypTI38XF1I
+  date: 2017-08-08
+  title: "Cosyris Trailer"
+  author: "Pipou"
+- id: esr_vhu0JrQ
+  date: 2017-08-07
+  title: "[Ger] Teeworlds DDnet 4th Birthday Last Tournament Stream - brainduck"
+  author: "KlexMikrowelle"
+- id: bf1WywD4xL0
+  date: 2017-08-03
+  title: "[Ger] Teeworlds  Highlife Livestream mit Panik und Exil"
+  author: "KlexMikrowelle"
+- id: lSy9bepW-O4
+  date: 2017-08-02
+  title: "brainduck - DDNet 4th Birthday Tournament Last Map - Sunday 6th August"
+  author: "KlexMikrowelle"
+- id: lhcbyUJ11LU
+  date: 2017-08-01
+  title: "[Ger] Teeworlds  Maui Wowie 2 Livestream mit Panik"
+  author: "KlexMikrowelle"
+- id: T38qBSn0Wb4
+  date: 2017-07-31
+  title: "DDnet - Birthday Tournament | Back in the days 3 (Team 0)"
+  author: "Ryozuki"
+- id: GPX8qagAt1s
+  date: 2017-07-30
+  title: "[Ger] Teeworlds Tournament Livestream Back in the days 3 mit Panik und Klex"
+  author: "KlexMikrowelle"
+- id: k04TinlRC7g
+  date: 2017-07-29
+  title: "[Ger] Teeworlds Tournament Livestream Rogue World mit Panik"
+  author: "KlexMikrowelle"
+- id: sELsw2I2jj8
+  date: 2017-07-26
+  title: "[Eng] Teeworlds New Binding Tutorial by Klex"
+  author: "KlexMikrowelle"
+- id: mOV2i7Engsc
+  date: 2017-07-25
+  title: "[Ger] Teeworlds SkyLand2 Livestream mit Klex Exilwarrior und Panik"
+  author: "KlexMikrowelle"
+- id: v0yhSBCcXWk
+  date: 2017-07-23
+  title: "DDNet - Pros Play TW 88: Haw Bout Dat!?"
+  author: "Aoe"
+- id: jTP-Oz05IN4
+  date: 2017-06-01
+  title: "Funny Moments 8 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: Tn_wX1UxfNU
+  date: 2017-04-19
+  title: "WoodDivision V: Rank 1 - DDNet [Teeworlds] 60 FPS"
+  author: "KriXx TeeWorlds"
+- id: I2NGiE1bbfA
+  date: 2017-04-10
+  title: "Teeworlds DDRace Tournament mit RayB."
+  author: "Habekein Namen"
+- id: JDtzodZPBv8
+  date: 2017-03-21
+  title: "Teeworlds DDRaceNetwork Tournament #44"
+  author: "Habekein Namen"
+- id: lZX7mNbeCM0
+  date: 2017-02-06
+  title: "DDRace Noob School - Episode 1: Using Brain"
+  author: "Aoe"
+- id: _nry2AbZlWE
+  date: 2017-01-09
+  title: "DDNet - Pros Play TW 83: Lost Tapes #1"
+  author: "Aoe"
+- id: ofGWeGkQ_UQ
+  date: 2017-01-03
+  title: "Static Survivorz - Teeworlds Montage [DDrace/Gores] [ChillerDragon]"
+  author: "Prudrugtiq"
+- id: Sw7nnodYbbw
+  date: 2016-12-15
+  title: "Teeworlds - Genericore 7 Rank 1"
+  author: "KlexMikrowelle"
+- id: J3qBosr-lOY
+  date: 2016-10-10
+  title: "Mirai Rank1 [Time 12:27] [Teeworlds]"
+  author: "Saro Teeworlds"
+- id: W8bJmI4Y-5I
+  date: 2016-09-21
+  title: "Fail Moments 3 [DDNet] Teeworlds"
+  author: "Grk0ne"
+- id: qbUYubtQNk4
+  date: 2016-09-14
+  title: "Teeworlds Fade Trailer"
+  author: "SilexTw"
+- id: crDZ8ioYT5s
+  date: 2016-08-29
+  title: "GenericDrag ★★★★ TOP1 - kezo + 60fps | TeeWorlds , DDNet"
+  author: "TeeWorlds Runs"
+- id: lXuQKqxNwx0
+  date: 2016-08-26
+  title: "Desert Night rank 1 (Teeworlds)"
+  author: "fikmesån"
+- id: GBtb9PlJg3c
+  date: 2016-08-18
+  title: "Solo_Mietzcore — 15:58.3 — DDNet [Teeworlds]"
+  author: "gdin teeworlds"
+- id: BCMiTWt6Lf4
+  date: 2016-08-12
+  title: "Teeworlds fail montage 5"
+  author: "fikmesån"
+- id: 6aKP6XX2KgE
+  date: 2016-08-08
+  title: "DDNet: Handifly Speedrun"
+  author: "Aoe"
+- id: 9B6jNA2P8vs
+  date: 2016-07-29
+  title: "run_antibuguse — 1177:37.50 — DDNet [Teeworlds]"
+  author: "gdin teeworlds"
+- id: JoFXILLaHHI
+  date: 2016-07-27
+  title: "Stoned 2 - Saro & Destin [Rank 1] [DDNet] [DDrace] [Teeworlds]"
+  author: "Prudrugtiq"
+- id: EC-vCSBr0mM
+  date: 2016-07-19
+  title: "Resi rank1 Time: 2:28"
+  author: "Saro Teeworlds"
+- id: Rr5y7ErLtmU
+  date: 2016-07-14
+  title: "Hell Fly Rank 1 [Teeworlds]"
+  author: "Just Spyker"
+- id: t9IIRr-Hjrc
+  date: 2016-07-13
+  title: "miA ★★★★★ TOP1 - kezo (with a small skip) | TeeWorlds , DDNet"
+  author: "TeeWorlds Runs"
+- id: fdjeycFtgEA
+  date: 2016-07-09
+  title: "SkipBusters: Episode 1 — Executive"
+  author: "gdin teeworlds"
+- id: 6TEYy4FYS5k
+  date: 2016-06-28
+  title: "500 Sub Special Part 1: mB. | dinner & mB. | maple Run Compilation"
+  author: "gdin teeworlds"
+- id: nGtnr2p7LdY
+  date: 2016-06-12
+  title: "Mapping with Ñı©Ø #1 - Let's learn the basics here!"
+  author: "NICO_THE_PRO"
+- id: KJCSutmzbR0
+  date: 2016-06-07
+  title: "Demo montage 2 (Teeworlds)"
+  author: "fikmesån"
+- id: 3_JxdxUn2E4
+  date: 2016-06-02
+  title: "Dummy Chamber — 2:01.50 — DDNet [Teeworlds]"
+  author: "gdin teeworlds"
+- id: wzfSDzgP6mA
+  date: 2016-05-16
+  title: "DDNet Quick Tournament #43 1st Place — 10:05.88 [Teeworlds]"
+  author: "gdin teeworlds"
+- id: bilmnke_Lcs
+  date: 2016-05-03
+  title: "Demo montage (Teeworlds)"
+  author: "fikmesån"
+- id: 3-O7c_peca8
+  date: 2016-04-29
+  title: "DDNet: Infamous Clan"
+  author: "Aoe"
+- id: TzCD0xapMwo
+  date: 2016-04-27
+  title: "Naufrage 3 Rank 1 [Teeworlds]"
+  author: "Just Spyker"
+- id: cqCIv6NzR1s
+  date: 2016-04-17
+  title: "Sand Dune Rank 1"
+  author: "Just Spyker"
+- id: gZod3lwXbIU
+  date: 2016-04-09
+  title: "Teeworlds Adrenaline 5 Trailer"
+  author: "SilexTw"
+- id: qIPUwY3dStA
+  date: 2016-04-04
+  title: "Increase Rank 1 [Teeworlds]"
+  author: "Just Spyker"
+- id: -V7DldslhXY
+  date: 2016-03-27
+  title: "Aim 11.0 Rank 1 [Teeworlds]"
+  author: "Just Spyker"
+- id: O3ZJbzDXtTs
+  date: 2016-03-15
+  title: "Teeworlds fail montage 3"
+  author: "fikmesån"
+- id: 9SVQvfRsrow
+  date: 2016-02-20
+  title: "[DDNet] JungleBee - gdin"
+  author: "DDraceNetwork - Hall of Fame"
+- id: s7jLQ0zdFLE
+  date: 2016-02-15
+  title: "[DDNet] Mud - Noved"
+  author: "DDraceNetwork - Hall of Fame"
+- id: rKQxL-2SXKM
+  date: 2016-02-12
+  title: "[DDNet] Flying in the Sky - Seba0006 & Zuko"
+  author: "DDraceNetwork - Hall of Fame"
+- id: InSSAHofoh8
+  date: 2016-02-06
+  title: "[DDNet] 1of4 - 4of4 Compilation - gdin"
+  author: "DDraceNetwork - Hall of Fame"
+- id: wrxbiCx3IUc
+  date: 2016-02-04
+  title: "Impossible 2 & 3 - Teamplay Rank 1 [Teeworlds]"
+  author: "Shocker"
+- id: LJaPVmREWys
+  date: 2016-01-24
+  title: "The Fusion Rank 1 [Teeworlds]"
+  author: "Just Spyker"
+- id: oSrCjtI535Y
+  date: 2016-01-09
+  title: "Teeworlds DDrace - Simple Play Done Quick"
+  author: "Ryozuki"
+- id: qggFdeGk1pU
+  date: 2015-12-30
+  title: "DDNet - Happy New Years Special Montage"
+  author: "Aoe"
+- id: FHmeGGXKIkE
+  date: 2015-12-15
+  title: "Teeworlds - Just Enjoy [DDNet]"
+  author: "Magino"
+- id: -RkKIMTxzyU
+  date: 2015-12-10
+  title: "Spallok Top1 — 1:42.76 — DDNet [Teeworlds]"
+  author: "gdin teeworlds"
+- id: HiB9pg2dQSQ
+  date: 2015-10-01
+  title: "Funny montage 2 (Fail montage) by ZiKkie"
+  author: "TwiceRus"
+- id: mCodW2aEqoY
+  date: 2015-09-26
+  title: "DDNet - Pros Play TW 18: 1'st Rank"
+  author: "Aoe"
+- id: NZqIFUzzXXg
+  date: 2015-09-24
+  title: "DDNet - Pros Play TW 17: Ntumba!"
+  author: "Aoe"
+- id: xlmjpRk8jiY
+  date: 2015-09-24
+  title: "Teeworlds Movie - Speedrun RUN_YELLOW [EPISODE #2]"
+  author: "rmXSavander"
+- id: z8MQftwmdgM
+  date: 2015-09-16
+  title: "JustGeneric — 12:28 — DDNet Tournament run (DDNet, Teeworlds)"
+  author: "milk teeworlds"
+- id: bRIYfPvXKLQ
+  date: 2015-09-14
+  title: "#39 Brütal Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: 1Pq2A4WGXgw
+  date: 2015-09-12
+  title: "Summer Hell Rank 1 [Teeworlds]"
+  author: "Just Spyker"
+- id: LTGEUrASRBI
+  date: 2015-09-09
+  title: "[Teeworlds] DDNet — solo_castle Top1 — 0:18.20"
+  author: "gdin teeworlds"
+- id: D-BYPjibuv8
+  date: 2015-09-08
+  title: "[Teeworlds] DDNet — xyz_ddrace2 Top1 — 3:14.88"
+  author: "gdin teeworlds"
+- id: AbUaGCVsTnc
+  date: 2015-08-30
+  title: "#38 1/3 Solo Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: VoAum1KIpp8
+  date: 2015-08-27
+  title: "Teeworlds Movie  - This is DDrace (100 Sub special)"
+  author: "Ryozuki"
+- id: CeIxXseaOvo
+  date: 2015-08-24
+  title: "[Teeworlds] DDNet — Goo! Top1"
+  author: "gdin teeworlds"
+- id: xwyk4hPZM1g
+  date: 2015-08-18
+  title: "DDNet - DDraceNetwork Trailer"
+  author: "Aoe"
+- id: m9VxLj9AGCo
+  date: 2015-08-17
+  title: "Adragaline — 02:14 — Faily skip! (DDNet, Teeworlds)"
+  author: "milk teeworlds"
+- id: QT830Pp4or0
+  date: 2015-08-14
+  title: "SoManyStars — 00:39.04 (DDNet, Teeworlds)"
+  author: "milk teeworlds"
+- id: nD6gJOZ6WjY
+  date: 2015-08-13
+  title: "Teeworlds DDrace - Raid"
+  author: "Ryozuki"
+- id: Th2WErYeho0
+  date: 2015-08-10
+  title: "[Teeworlds]][DDRace #5]"
+  author: "Sambio-Tw"
+- id: NPorNO-FdBA
+  date: 2015-08-06
+  title: "[Teeworlds] DDNet - a_simple_run Top1"
+  author: "gdin teeworlds"
+- id: o2zgV1t-Jww
+  date: 2015-08-01
+  title: "Teeworlds Black&White Trailer (ddrace map by TyxpekCZ)"
+  author: "Fňokurka"
+- id: N1OnOxBIdy4
+  date: 2015-07-26
+  title: "DDNet - Pros Play TW 5 Part 1: Adrenaline!"
+  author: "Aoe"
+- id: ON5NIS6i5bc
+  date: 2015-07-23
+  title: "Teeworlds Adragaline 2 Trailer"
+  author: "SilexTw"
+- id: M5hsBsN6HKM
+  date: 2015-07-21
+  title: "Teeworlds ddrace map Vizur 2 - Seba0006 y The.Rorroo♫"
+  author: "Rorro9876"
+- id: Np_tD-gdQfQ
+  date: 2015-07-21
+  title: "TeeWorlds DDnet 2nd Birthday Tournament"
+  author: "Ryozuki"
+- id: eW9-1UKCLa4
+  date: 2015-07-19
+  title: "#37 Happy Birthday Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: kvBI893-8qw
+  date: 2015-07-14
+  title: "Teeworlds ddrace Map gold mine - YeizouTheTurtle y The.Rorroo ♫"
+  author: "Rorro9876"
+- id: UqJHBZsdv1U
+  date: 2015-07-13
+  title: "Teeworlds Fails - [EPISODE #1]"
+  author: "rmXSavander"
+- id: LVO06dWiXOc
+  date: 2015-07-12
+  title: "TeeWorlds Tricks Movie  [1080p 60FPS]"
+  author: "Ryozuki"
+- id: qCP_Wj-ILtY
+  date: 2015-07-07
+  title: "Teeworlds DDRace Adrenaline 3"
+  author: "deen"
+- id: GzQYIBZQJFM
+  date: 2015-06-28
+  title: "#36 Brütal Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: JObJvGL_2IA
+  date: 2015-06-22
+  title: "[Event] TeeWorlds 50/60 Tees hammerfly + Bonus!"
+  author: "Ryozuki"
+- id: DGxDwr4nG3c
+  date: 2015-06-15
+  title: "Moderate Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: lAYfVqUbcPM
+  date: 2015-06-14
+  title: "[Teeworlds] DDNet - Art of Movement Top1 (Crazy Skip!)"
+  author: "gdin teeworlds"
+- id: pxy5-rELdsU
+  date: 2015-06-04
+  title: "Trailer Desert Wolf [Teeworlds]"
+  author: "Just Spyker"
+- id: idHnfGVsup0
+  date: 2015-05-28
+  title: "Naufrage 2 Rank 1 [Teeworlds]"
+  author: "Just Spyker"
+- id: _UQ0cMEHG44
+  date: 2015-05-16
+  title: "Milthrid Core Rank 1 [Teeworlds]"
+  author: "Just Spyker"
+- id: 0XKmAx1rT-c
+  date: 2015-04-18
+  title: "DarkSpy Tournament Trailer 1 [Teeworlds]"
+  author: "Just Spyker"
+- id: 7g85QXkoVgI
+  date: 2015-03-30
+  title: "InVirus Montage [Teeworlds]"
+  author: "Just Spyker"
+- id: 9lqCjZ9oaBk
+  date: 2015-03-19
+  title: "[Teeworlds] DDNet - Movement I Top1"
+  author: "gdin teeworlds"
+- id: zjRR2eCN2e4
+  date: 2015-03-04
+  title: "TeeWorlds DDrace Just2Easy #3 - Ryozuki"
+  author: "Ryozuki"
+- id: gK9YRtyRVTQ
+  date: 2015-02-07
+  title: "Simple Play Rank 1 [Teeworlds]"
+  author: "Just Spyker"
+- id: z-Qzw6KHYXY
+  date: 2015-01-27
+  title: "Teeworld Speedrun levi (with hi_leute_gll)"
+  author: "teachertube"
+- id: nKFMF6BeR4U
+  date: 2014-12-25
+  title: "Special[2] - Christmas 2014"
+  author: "teeworlds-artkis"
+- id: vzghqtCFSTw
+  date: 2014-12-14
+  title: "Teeworlds - THIS IS ENTERTAINMENT [DDRace]"
+  author: "Magino"
+- id: sWn90CiWHSE
+  date: 2014-12-04
+  title: "[DDNet] Senani - Maple & Skeith"
+  author: "DDraceNetwork - Hall of Fame"
+- id: XxH7b-VjbpM
+  date: 2014-11-25
+  title: "[DDNet] deathpack - Maple"
+  author: "DDraceNetwork - Hall of Fame"
+- id: I8T3EFRgEkg
+  date: 2014-11-19
+  title: "Race[17] - Gridwyn - Fudgyking - Nealson - Rapture & others"
+  author: "teeworlds-artkis"
+- id: k4RCUCJAnEE
+  date: 2014-11-09
+  title: "[DDNet] Kobra 3 Solo - RedFight"
+  author: "DDraceNetwork - Hall of Fame"
+- id: Vn5mt6I4wgw
+  date: 2014-10-30
+  title: "[DDNet] Hell's Castle - darky"
+  author: "DDraceNetwork - Hall of Fame"
+- id: NuQwNjn32Qo
+  date: 2014-10-28
+  title: "Brutal DummyDrag Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: jzjSFVD3a8Q
+  date: 2014-10-20
+  title: "Moderate Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: fKHY_b4u5oI
+  date: 2014-10-14
+  title: "Moderate Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: v_1WScNETH4
+  date: 2014-10-11
+  title: "[DDNet] Spallok - levi"
+  author: "DDraceNetwork - Hall of Fame"
+- id: 710wt6JUG2o
+  date: 2014-10-01
+  title: "[DDNet] ROCKET-BELT - Maple"
+  author: "DDraceNetwork - Hall of Fame"
+- id: r3jR-vLfnJs
+  date: 2014-09-30
+  title: "Novice Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: VLYfxtQwleM
+  date: 2014-09-28
+  title: "[DDNet] PetJack 2 - Moiman"
+  author: "DDraceNetwork - Hall of Fame"
+- id: 5u6nj4bpLoM
+  date: 2014-09-25
+  title: "Moderate Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: Q_0XitBSS9U
+  date: 2014-09-25
+  title: "[DDNet] Chill Let's Climb - Maple"
+  author: "DDraceNetwork - Hall of Fame"
+- id: sgvOnGvrZSk
+  date: 2014-09-15
+  title: "Moderate Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: g95KvF6wLQE
+  date: 2014-09-14
+  title: "[DDNet] Flying in the Sky - Ninja33 & gB. | ħίɴɖU"
+  author: "DDraceNetwork - Hall of Fame"
+- id: 2rYvkfFj9SA
+  date: 2014-09-13
+  title: "[DDNet] FWYS Key 1 - // red & gB. | ħίɴɖU"
+  author: "DDraceNetwork - Hall of Fame"
+- id: UUruzTbQOhY
+  date: 2014-09-12
+  title: "[DDNet] Naufrage 2 - 'qZ |BlaGK|› & SickCunt"
+  author: "DDraceNetwork - Hall of Fame"
+- id: wZfgs4wylRs
+  date: 2014-09-11
+  title: "Teeworlds - laxa runs Verification 9.0 and Verification 9.1"
+  author: "laxa"
+- id: 4Y4YW9JzsT4
+  date: 2014-08-22
+  title: "AIB Quest 2 : The Holy Tree"
+  author: "Pipou"
+- id: GRV5yWCyYIg
+  date: 2014-08-08
+  title: "Brütal Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: WQ17c5gh7bs
+  date: 2014-07-25
+  title: "Novice Teeworlds DDNET Tournament [FullHD]"
+  author: "Hallowed1986"
+- id: USbsQnu6AS8
+  date: 2014-07-03
+  title: "Fun[21] - Nealson T'nP pro dummy dragger"
+  author: "teeworlds-artkis"
+- id: QWLyp-3Mqhg
+  date: 2014-06-26
+  title: "DDraceNetwork - Art of Movement (Walljump map)"
+  author: "deen"
+- id: e2F95d-guUc
+  date: 2014-06-22
+  title: "Teeworlds - THE CREATIVE WAY TO DIE [DDRace]"
+  author: "Magino"
+- id: GJU2gYsp3gA
+  date: 2014-06-17
+  title: "Funniest Teeworlds Movie Ever"
+  author: "Danny W."
+- id: 6tui9XJxOdg
+  date: 2014-05-24
+  title: "DDraceNetwork Solo Jetpack Tournament"
+  author: "deen"
+- id: ApCo64AnIuI
+  date: 2014-05-05
+  title: "Teeworlds Funny montage (ddrace) by ZiKkie"
+  author: "TwiceRus"

--- a/www/_layouts/default.html
+++ b/www/_layouts/default.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link rel="stylesheet" type="text/css" href="/css.css?version=27" />
+    <link rel="stylesheet" type="text/css" href="/css.css?version=28" />
     <link rel="stylesheet" type="text/css" href="/css-halloween.css?version=8" />
 
     <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">

--- a/www/css.css
+++ b/www/css.css
@@ -1133,3 +1133,33 @@ body#phpbb .attachbox dl.thumbnail a::after {
   gap: 5px;
   justify-content: space-around;
 }
+
+.startvideo-caption {
+  margin: 0.3em 0 0 0;
+  font-size: 90%;
+  text-align: right;
+}
+
+.videogrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(18em, 1fr));
+  gap: 1em;
+  text-align: left;
+}
+
+.videogrid-item {
+  margin: 0;
+}
+
+.videogrid-item figcaption {
+  padding-top: 0.4em;
+  font-size: 90%;
+  line-height: 1.3;
+}
+
+.videogrid-meta {
+  display: block;
+  padding-top: 0.2em;
+  font-size: 85%;
+  opacity: 0.7;
+}

--- a/www/index.php
+++ b/www/index.php
@@ -12,9 +12,13 @@ menu-extern: subnav
 <p>
 DDraceNetwork (DDNet) is an actively maintained version of DDRace, a <a href="https://www.teeworlds.com/">Teeworlds</a> modification with a unique cooperative gameplay. Help each other play through <a href="/releases/">custom maps</a> with up to 64 players, compete against the best in <a href="/tournaments/">international tournaments</a>, design your <a href="/howto/">own maps</a>, or run your <a href="/settingscommands/">own server</a>. The <a href="/status/">official servers</a> are around the world. All <a href="/ranks/">ranks</a> made on official servers are available worldwide and you can <a href="/players/">collect points</a>!
 </p>
-<div class="startvideo"><div class="video-container">
-  <div class="ytplayer" data-id="wGBvuIM7FXQ"></div>
-</div></div>
+{% assign featured = site.data.videos | first %}
+<div class="startvideo">
+  <div class="video-container">
+    <div class="ytplayer" data-id="{{ featured.id }}"></div>
+  </div>
+  <p class="startvideo-caption"><a href="/videos/">More community videos</a></p>
+</div>
 {% comment %}
 <style>
     .twitch-embed{

--- a/www/videos/feed/index.atom
+++ b/www/videos/feed/index.atom
@@ -1,0 +1,28 @@
+---
+layout: null
+---
+
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+
+ <title>{{ site.title }} Videos</title>
+ <link href="{{ site.url }}/videos/feed/" rel="self"/>
+ <link href="{{ site.url }}/videos/"/>
+ {% assign newest = site.data.videos | first %}
+ <updated>{{ newest.date | date_to_xmlschema }}</updated>
+ <id>{{ site.url }}/videos/</id>
+ <author>
+   <name>{{ site.author.name }}</name>
+ </author>
+
+ {% for video in site.data.videos limit:20 %}
+ <entry>
+   <title>{{ video.title | default: video.id | xml_escape }}</title>
+   <link href="https://www.youtube.com/watch?v={{ video.id }}"/>
+   <updated>{{ video.date | date_to_xmlschema }}</updated>
+   <id>https://www.youtube.com/watch?v={{ video.id }}</id>
+   {% if video.author %}<author><name>{{ video.author | xml_escape }}</name></author>{% endif %}
+   <content type="html"><![CDATA[<p><a href="https://www.youtube.com/watch?v={{ video.id }}"><img src="https://i.ytimg.com/vi/{{ video.id }}/hqdefault.jpg" alt="{{ video.title | xml_escape }}"/></a></p>]]></content>
+ </entry>
+ {% endfor %}
+</feed>

--- a/www/videos/index.html
+++ b/www/videos/index.html
@@ -1,0 +1,36 @@
+---
+layout: default
+title: Videos - DDraceNetwork
+head: |
+  <link rel="alternate" type="application/atom+xml" title="DDNet Videos" href="/videos/feed/" />
+  <script src="/youtube.js?version=4" type="text/javascript"></script>
+menu-extern: subnav
+---
+<div class="block">
+  <h2>Videos <a href="/videos/feed/"><img width="24" class="image-icon" src="/feed.svg" alt="Feed"/></a></h2>
+  <p>
+    {% assign oldest = site.data.videos | last %}
+    Every video we have featured on the <a href="/">frontpage</a>, newest first. Made by
+    the community, showing off runs, maps, tournaments and trailers from
+    {{ oldest.date | date: "%Y" }} onwards.
+  </p>
+</div>
+
+{% assign years = site.data.videos | group_by_exp: "video", "video.date | date: '%Y'" %}
+{% for year in years %}
+<div class="block">
+  <h3 id="{{ year.name }}">{{ year.name }}</h3>
+  <div class="videogrid">
+    {% for video in year.items %}
+    {% assign author = video.author | default: "" %}
+    <figure class="videogrid-item">
+      <div class="video-container"><div class="ytplayer" data-id="{{ video.id }}"></div></div>
+      <figcaption>
+        <a href="https://www.youtube.com/watch?v={{ video.id }}">{{ video.title | default: "Watch on YouTube" | escape }}</a>
+        <span class="videogrid-meta">{% if author != "" %}{{ author | escape }}, {% endif %}featured {{ video.date | date: "%Y-%m-%d" }}</span>
+      </figcaption>
+    </figure>
+    {% endfor %}
+  </div>
+</div>
+{% endfor %}

--- a/www/youtube.js
+++ b/www/youtube.js
@@ -19,6 +19,7 @@ window.onload = function() {
           this.style.visibility = 'visible';
         }
       }
+      img.loading = 'lazy';
       img.src = 'https://i.ytimg.com/vi/' + v[n].dataset.id + '/maxresdefault.jpg';
       img.style.visibility = 'hidden';
       div.appendChild(img);


### PR DESCRIPTION
We have been putting a community video on the frontpage since 2014 and then quietly replacing it a few weeks later. This adds `/media/` so none of them get lost.

I pulled the list out of git history, 838 commits total, which turned up 327 videos going back to May 2014. 
22 have since been deleted or made private, so the page shows the 305 that still play.

The frontpage no longer hardcodes the video id. `www/_data/videos.yml` is the source of truth and `index.php` renders its first entry, so featuring a video and archiving it are the same edit.

New videos can be added with the python script: `python add_video.py <id or url>`
Fetches the title and channel from YouTube, stamps today's date, inserts it at the top.
<img width="2560" height="1279" alt="firefox_oIcgu4ks9a" src="https://github.com/user-attachments/assets/79906354-570b-408d-91a1-5c8ea5c23a01" />
