### PR TITLE
Move both sidebar menus into `_data/menus.yml`

### DIFF
--- a/www/_data/menus.yml
+++ b/www/_data/menus.yml
@@ -1,3 +1,32 @@
+nav: |
+  <ul class="big">
+    <li><a href="/status/">Status</a></li>
+    <li><a href="/ranks/">Ranks</a></li>
+    <li><a href="/releases/">Map Releases</a></li>
+    <li><a href="/discord">Discord</a> / <a href="//forum.ddnet.org/">Forum</a></li>
+    <li><a href="//wiki.ddnet.org/">Wiki</a></li>
+    <li><a href="/downloads/">Downloads</a> / <a href="/steam/">Steam</a></li>
+    <li><a href="/tournaments/">Tournaments</a></li>
+    <li><a href="/skins/">Skin Database</a></li>
+    <li><a href="/stats/">Statistics</a></li>
+    <li><a href="/staff/">Staff &amp; Contact</a></li>
+    <li><a href="/switch-theme/">Switch Theme</a></li>
+  </ul>
+
+subnav: |
+  <ul>
+    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
+    <li><a href="/server/">Server&nbsp;Features</a></li>
+    <li><a href="/client/">Client&nbsp;Features</a></li>
+    <li><a href="/map/">Map&nbsp;Features</a></li>
+    <li><a href="/mapping/">Mapping</a></li>
+    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
+    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
+    <li><a href="/rules/">Rules</a></li>
+    <li><a href="/renames/">Renames</a></li>
+    <li><a href="/funding/">Funding</a></li>
+  </ul>
+
 explain-layers: |
   <ul>
     <li><a href="/explain/">Entities overlay</a></li>

--- a/www/_layouts/default.html
+++ b/www/_layouts/default.html
@@ -38,19 +38,7 @@
       <div class="fade">
         <menu class="contentleft">
         <div class="title"><h1><a href="/"><img class="logobig" alt="DDraceNetwork" src="/ddnet2.svg"/><img class="logosmall" alt="DDraceNetwork" src="/ddnet.svg"/></a></h1></div>
-          <ul class="big">
-            <li><a href="/status/">Status</a></li>
-            <li><a href="/ranks/">Ranks</a></li>
-            <li><a href="/releases/">Map Releases</a></li>
-            <li><a href="/discord">Discord</a> / <a href="//forum.ddnet.org/">Forum</a></li>
-            <li><a href="//wiki.ddnet.org/">Wiki</a></li>
-            <li><a href="/downloads/">Downloads</a> / <a href="/steam/">Steam</a></li>
-            <li><a href="/tournaments/">Tournaments</a></li>
-            <li><a href="/skins/">Skin Database</a></li>
-            <li><a href="/stats/">Statistics</a></li>
-            <li><a href="/staff/">Staff &amp; Contact</a></li>
-            <li><a href="/switch-theme/">Switch Theme</a></li>
-          </ul>
+          {{ site.data.menus.nav | flatify }}
           {{ page.menu | flatify }}
           {{ site.data.menus[page.menu-extern] | flatify }}
         </menu>

--- a/www/_layouts/post.html
+++ b/www/_layouts/post.html
@@ -40,19 +40,7 @@
       <div class="fade">
         <menu class="contentleft">
         <div class="title"><h1><a href="/"><img class="logobig" alt="DDraceNetwork" src="/ddnet2.svg"/><img class="logosmall" alt="DDraceNetwork" src="/ddnet.svg"/></a><div class="fade"></div></h1></div>
-          <ul class="big">
-            <li><a href="/status/">Status</a></li>
-            <li><a href="/ranks/">Ranks</a></li>
-            <li><a href="/releases/">Map Releases</a></li>
-            <li><a href="/discord">Discord</a> / <a href="//forum.ddnet.org/">Forum</a></li>
-            <li><a href="//wiki.ddnet.org/">Wiki</a></li>
-            <li><a href="/downloads/">Downloads</a> / <a href="/steam/">Steam</a></li>
-            <li><a href="/tournaments/">Tournaments</a></li>
-            <li><a href="/skins/">Skin Database</a></li>
-            <li><a href="/stats/">Statistics</a></li>
-            <li><a href="/staff/">Staff &amp; Contact</a></li>
-            <li><a href="/switch-theme/">Switch Theme</a></li>
-          </ul>
+          {{ site.data.menus.nav | flatify }}
           <ul>
             <li><a href="/news/">All News</a></li>
           </ul>

--- a/www/client/index.html
+++ b/www/client/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: Client Features - DDraceNetwork
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 <div class="block">
 <h2 id="client-features">Client Features</h2>

--- a/www/funding/index.html
+++ b/www/funding/index.html
@@ -2,19 +2,7 @@
 layout: default
 title: Funding - DDraceNetwork
 head: <link rel="stylesheet" href="jquery-ui-1.8.22.custom.css" />
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 <div class="block">
 <h2 id="funding">Funding</h2>

--- a/www/index.php
+++ b/www/index.php
@@ -5,19 +5,7 @@ head: |
   <link rel="alternate" type="application/atom+xml" title="DDNet News" href="/feed/" />
   <link rel="stylesheet" href="/funding/jquery-ui-1.8.22.custom.css" />
   <script src="/youtube.js?version=3" type="text/javascript"></script>
-menu: |
-  <ul>
-    <li><a href="#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 <div class="block">
 <h2>DDRace Servers and much more!</h2>

--- a/www/map/index.html
+++ b/www/map/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: Map Features - DDraceNetwork
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 <div class="block">
 <h2 id="map-features">Map Features</h2>

--- a/www/mapping/auto-font/index.html
+++ b/www/mapping/auto-font/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: Teeworlds Auto-Font
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 head: |
   <style>
     .autofont * {

--- a/www/mapping/guidelines/index.html
+++ b/www/mapping/guidelines/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: Mapping Guidelines - DDraceNetwork
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 
 <div class="block">

--- a/www/mapping/index.html
+++ b/www/mapping/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: Mapping - DDraceNetwork
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 <div class="block">
   <h2 id="mapping">Mapping</h2>

--- a/www/mapping/rules/index.html
+++ b/www/mapping/rules/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: Mapping Rules - DDraceNetwork
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 
 <div class="block">

--- a/www/olddomain/index.html
+++ b/www/olddomain/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: DDNet.tw Domain lost, use DDNet.org
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 <div class="block">
   <h2 id="compromised-domain-notice">UPDATE</h2>

--- a/www/renames/index.html
+++ b/www/renames/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: Renames - DDraceNetwork
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 <div class="block">
 <h2 id="renames">Renames</h2>

--- a/www/rules/community/index.html
+++ b/www/rules/community/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: Community Rules - DDraceNetwork
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 <div class="block">
   <h2 id="community-rules">Community Rules</h2>

--- a/www/rules/index.html
+++ b/www/rules/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: Rules - DDraceNetwork
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 <div class="block">
   <h2 id="rules">Rules</h2>

--- a/www/rules/master/index.html
+++ b/www/rules/master/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: Masterserver Rules - DDraceNetwork
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 <div class="block">
   <h2 id="master-rules">Masterserver Rules</h2>

--- a/www/server/index.html
+++ b/www/server/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: Server Features - DDraceNetwork
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 <div class="block">
 <h2 id="server-features">Server Features</h2>

--- a/www/vpn/index.html
+++ b/www/vpn/index.html
@@ -1,19 +1,7 @@
 ---
 layout: default
 title: VPN Ban Notice - DDraceNetwork
-menu: |
-  <ul>
-    <li><a href="/#news">News</a> (<a href="/news/">all</a>)</li>
-    <li><a href="/server/">Server&nbsp;Features</a></li>
-    <li><a href="/client/">Client&nbsp;Features</a></li>
-    <li><a href="/map/">Map&nbsp;Features</a></li>
-    <li><a href="/mapping/">Mapping</a></li>
-    <li><a href="/binds/">Useful&nbsp;Binds</a></li>
-    <li><a href="/settingscommands/">Settings&nbsp;&amp;&nbsp;Commands</a></li>
-    <li><a href="/rules/">Rules</a></li>
-    <li><a href="/renames/">Renames</a></li>
-    <li><a href="/funding/">Funding</a></li>
-  </ul>
+menu-extern: subnav
 ---
 <div class="block">
   <h2 id="vpn-ban-notice_en">VPN Ban Notice</h2>


### PR DESCRIPTION
You could clean up the copy-pasta if you want!
_Originally posted by @def- in https://github.com/ddnet/ddnet-web/issues/374#issuecomment-5132198795_

The top menu was copy-pasted into default.html and post.html, and the lower menu into the front matter of 15 pages. 
I built the site before and after and compared most relevant pages. This should make adding a link a single edit instead of 2 or 16!

If I missed one, let me know.